### PR TITLE
US 24 - Ver listado de usuarios

### DIFF
--- a/src/main/java/com/dylabs/zuko/controller/UserController.java
+++ b/src/main/java/com/dylabs/zuko/controller/UserController.java
@@ -10,6 +10,8 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
+
 @RestController
 @RequestMapping("users")
 @RequiredArgsConstructor
@@ -27,6 +29,12 @@ public class UserController {
     public ResponseEntity<UserResponse> login(@Valid @RequestBody LoginRequest request) {
         UserResponse response = userService.login(request);
         return ResponseEntity.ok(response);
+    }
+
+    @GetMapping
+    public ResponseEntity<List<UserResponse>> getAllUsers() {
+        List<UserResponse> users = userService.getAllUsers();
+        return new ResponseEntity<>(users, HttpStatus.OK);
     }
 
 }

--- a/src/main/java/com/dylabs/zuko/service/UserService.java
+++ b/src/main/java/com/dylabs/zuko/service/UserService.java
@@ -74,6 +74,9 @@ public class UserService {
         return userMapper.toResponse(user);
     }
 
-    /// Crud
+    public List<UserResponse> getAllUsers() {
+        List<User> users = userRepository.findAll();
+        return users.stream().map(userMapper::toResponse).toList();
+    }
 
 }


### PR DESCRIPTION
Se agregó un endpoint que permite obtener una lista completa de todos los usuarios del sistema.

Se implementó la conversión de cada usuario a su representación en el DTO (UserResponse) para ser devuelto como respuesta.

Se gestionaron los posibles errores, asegurando que la respuesta sea exitosa incluso si no hay usuarios registrados.

El sistema devuelve una respuesta con formato estándar (ApiResponse) confirmando que la operación se realizó exitosamente.