### PR TITLE
US 25 - Cambiar estado de actividad de cuenta

### DIFF
--- a/src/main/java/com/dylabs/zuko/controller/UserController.java
+++ b/src/main/java/com/dylabs/zuko/controller/UserController.java
@@ -37,4 +37,10 @@ public class UserController {
         return new ResponseEntity<>(users, HttpStatus.OK);
     }
 
+    @PatchMapping("/{id}/toggle-active")
+    public ResponseEntity<String> toggleUserActiveStatus(@PathVariable Long id) {
+        userService.toggleUserActiveStatus(id);
+        return ResponseEntity.ok("Estado de actividad del usuario actualizado correctamente.");
+    }
+
 }

--- a/src/main/java/com/dylabs/zuko/dto/request/CreateUserRequest.java
+++ b/src/main/java/com/dylabs/zuko/dto/request/CreateUserRequest.java
@@ -17,11 +17,12 @@ public record CreateUserRequest(
         @Size(min = 6, message = "La contraseña debe tener al menos 6 caracteres")
         String password,
 
-        String url_image, // Esto es opcional
+        String url_image,
 
         @Size(max = 250, message = "La descripción no puede exceder 250 caracteres")
         String description,
 
         @NotBlank(message = "El rol no puede estar vacío")
         String roleName // El nombre del rol, como "admin", "artista", etc.
+
 ) {}

--- a/src/main/java/com/dylabs/zuko/dto/response/UserResponse.java
+++ b/src/main/java/com/dylabs/zuko/dto/response/UserResponse.java
@@ -6,5 +6,6 @@ public record UserResponse(
         String email,
         String description,
         String url_image,
-        String roleName // El nombre del rol asignado
+        String roleName, // El nombre del rol asignado
+        boolean isActive
 ) {}

--- a/src/main/java/com/dylabs/zuko/mapper/UserMapper.java
+++ b/src/main/java/com/dylabs/zuko/mapper/UserMapper.java
@@ -18,7 +18,8 @@ public class UserMapper {
                 user.getEmail(),
                 user.getDescription(),
                 user.getUrl_image(),
-                user.getUserRoleName() // Obtener el nombre del rol
+                user.getUserRoleName(),
+                user.getIsActive()
         );
     }
 

--- a/src/main/java/com/dylabs/zuko/model/User.java
+++ b/src/main/java/com/dylabs/zuko/model/User.java
@@ -35,6 +35,10 @@ public class User {
     @JoinColumn(name = "role_id", nullable = false)
     private Role userRole;
 
+    @Column(nullable = false)
+    private boolean isActive;
+
+
     /// getters
 
     public String getUsername(){return username;}
@@ -52,6 +56,10 @@ public class User {
     public String getUserRoleName() {
         return userRole != null ? userRole.getRoleName() : null;
     }
+    public boolean getIsActive() {
+        return isActive;
+    }
+
 
 
     /// Setters
@@ -72,5 +80,8 @@ public class User {
         this.userRole = userRole;
     }
 
+    public void setActive(boolean active) {
+        isActive = active;
+    }
 
 }

--- a/src/main/java/com/dylabs/zuko/service/UserService.java
+++ b/src/main/java/com/dylabs/zuko/service/UserService.java
@@ -34,7 +34,8 @@ public class UserService {
                 user.getEmail(),
                 user.getUrl_image(),
                 user.getDescription(),
-                user.getUserRoleName()
+                user.getUserRoleName(),
+                user.getIsActive()
         );
     }
 
@@ -58,7 +59,10 @@ public class UserService {
         // 3. Asigna el rol
         user.setUserRole(userRole);
 
-        // 4. Guarda y responde
+        // 4. Establece el estado activo por defecto
+        user.setActive(true);
+
+        // 5. Guarda y responde
         User savedUser = userRepository.save(user);
         return userMapper.toResponse(savedUser);
     }
@@ -77,6 +81,14 @@ public class UserService {
     public List<UserResponse> getAllUsers() {
         List<User> users = userRepository.findAll();
         return users.stream().map(userMapper::toResponse).toList();
+    }
+
+    public void toggleUserActiveStatus(Long id) {
+        User user = userRepository.findById(id)
+                .orElseThrow(() -> new UserNotFoundExeption("Usuario con ID " + id + " no encontrado"));
+
+        user.setActive(!user.getIsActive());
+        userRepository.save(user);
     }
 
 }


### PR DESCRIPTION
Se agregó un endpoint PATCH /users/{id}/toggle-active que permite cambiar el estado de actividad de un usuario de manera toggle (activar o desactivar).

Se gestionó la lógica para actualizar el campo isActive del usuario y guardar el cambio en la base de datos.

La respuesta del endpoint es una confirmación de que el estado del usuario fue actualizado correctamente.

