### PR TITLE
US 17 - Mostrar perfil de usuario

### DIFF
--- a/src/main/java/com/dylabs/zuko/controller/UserController.java
+++ b/src/main/java/com/dylabs/zuko/controller/UserController.java
@@ -43,4 +43,10 @@ public class UserController {
         return ResponseEntity.ok("Estado de actividad del usuario actualizado correctamente.");
     }
 
+    @GetMapping("/{id}")
+    public ResponseEntity<UserResponse> getUserById(@PathVariable Long id) {
+        UserResponse response = userService.getUserById(id);
+        return ResponseEntity.ok(response);
+    }
+
 }

--- a/src/main/java/com/dylabs/zuko/service/UserService.java
+++ b/src/main/java/com/dylabs/zuko/service/UserService.java
@@ -91,4 +91,10 @@ public class UserService {
         userRepository.save(user);
     }
 
+    public UserResponse getUserById(Long id) {
+        User user = userRepository.findById(id)
+                .orElseThrow(() -> new UserNotFoundExeption("Usuario con ID " + id + " no encontrado"));
+        return userMapper.toResponse(user);
+    }
+
 }


### PR DESCRIPTION
Se agregó el endpoint GET /users/{id}, que permite obtener la información completa de un usuario a partir de su ID.

Se incluyó la lógica para recuperar el usuario desde la base de datos, verificando si existe. En caso de que no se encuentre, se devuelve un error adecuado.

El perfil del usuario incluye los detalles como el nombre de usuario, correo electrónico, imagen de perfil, descripción, rol, y el estado de actividad.

La respuesta incluye un objeto con la información completa del usuario para su visualización.