### PR TITLE
US 18 - Edición de perfil de usuario

### DIFF
--- a/src/main/java/com/dylabs/zuko/controller/UserController.java
+++ b/src/main/java/com/dylabs/zuko/controller/UserController.java
@@ -1,5 +1,6 @@
 package com.dylabs.zuko.controller;
 
+import com.dylabs.zuko.dto.ApiResponse;
 import com.dylabs.zuko.dto.request.CreateUserRequest;
 import com.dylabs.zuko.dto.request.LoginRequest;
 import com.dylabs.zuko.dto.request.UpdateUserRequest;
@@ -21,9 +22,9 @@ public class UserController {
     private final UserService userService;
 
     @PostMapping
-    public ResponseEntity<UserResponse> createUser(@Valid @RequestBody CreateUserRequest request) {
+    public ResponseEntity<ApiResponse<UserResponse>> createUser(@Valid @RequestBody CreateUserRequest request) {
         UserResponse response = userService.createUser(request);
-        return new ResponseEntity<>(response, HttpStatus.CREATED);
+        return new ResponseEntity<>(new ApiResponse<>("Usuario creado exitosamente", response), HttpStatus.CREATED);
     }
 
     @PostMapping("/login")

--- a/src/main/java/com/dylabs/zuko/controller/UserController.java
+++ b/src/main/java/com/dylabs/zuko/controller/UserController.java
@@ -2,6 +2,7 @@ package com.dylabs.zuko.controller;
 
 import com.dylabs.zuko.dto.request.CreateUserRequest;
 import com.dylabs.zuko.dto.request.LoginRequest;
+import com.dylabs.zuko.dto.request.UpdateUserRequest;
 import com.dylabs.zuko.dto.response.UserResponse;
 import com.dylabs.zuko.service.UserService;
 import jakarta.validation.Valid;
@@ -49,4 +50,10 @@ public class UserController {
         return ResponseEntity.ok(response);
     }
 
+    @PatchMapping("/{id}")
+    public ResponseEntity<UserResponse> updateUser(@PathVariable Long id,
+                                                   @Valid @RequestBody UpdateUserRequest updateRequest) {
+        UserResponse updatedUser = userService.updateUser(id, updateRequest);
+        return new ResponseEntity<>(updatedUser, HttpStatus.OK);
+    }
 }

--- a/src/main/java/com/dylabs/zuko/dto/ApiResponse.java
+++ b/src/main/java/com/dylabs/zuko/dto/ApiResponse.java
@@ -1,0 +1,19 @@
+package com.dylabs.zuko.dto;
+
+public class ApiResponse<T> {
+    private String message;
+    private T data;
+
+    public ApiResponse(String message, T data) {
+        this.message = message;
+        this.data = data;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+    public T getData() {
+        return data;
+    }
+}

--- a/src/main/java/com/dylabs/zuko/dto/request/CreateRoleRequest.java
+++ b/src/main/java/com/dylabs/zuko/dto/request/CreateRoleRequest.java
@@ -6,7 +6,7 @@ import jakarta.validation.constraints.Size;
 
 public record  CreateRoleRequest (
         @NotBlank(message="El nombre no puede estar vacío")
-        @Size(min=3, message = "El nombre del género debe tener al menos tres caracteres")
+        @Size(min=4, message = "El nombre del género debe tener al menos tres caracteres")
         String roleName,
         @Size(max=250,message = "La descripción no puede exceder 200 caracteres")
         String description

--- a/src/main/java/com/dylabs/zuko/dto/request/CreateUserRequest.java
+++ b/src/main/java/com/dylabs/zuko/dto/request/CreateUserRequest.java
@@ -2,6 +2,7 @@ package com.dylabs.zuko.dto.request;
 
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 
 public record CreateUserRequest(
@@ -13,6 +14,8 @@ public record CreateUserRequest(
         @Email(message = "El correo electrónico debe ser válido")
         String email,
 
+        @Pattern(regexp = "^(?=.*[A-Za-z])(?=.*\\d)[A-Za-z\\d!@#$%^&*()_+={}|\\[\\]\\\\:;\"'<>,.?/-]{6,}$",
+                message = "La contraseña debe contener al menos una letra, un número y puede contener símbolos.")
         @NotBlank(message = "La contraseña no puede estar vacía")
         @Size(min = 6, message = "La contraseña debe tener al menos 6 caracteres")
         String password,
@@ -22,7 +25,8 @@ public record CreateUserRequest(
         @Size(max = 250, message = "La descripción no puede exceder 250 caracteres")
         String description,
 
-        @NotBlank(message = "El rol no puede estar vacío")
-        String roleName // El nombre del rol, como "admin", "artista", etc.
+        String roleName, //El rolename no esta en notblank ya que si no se especifica en el request se asigna por defecto 'User'
+
+        Boolean isActive
 
 ) {}

--- a/src/main/java/com/dylabs/zuko/dto/request/UpdateUserRequest.java
+++ b/src/main/java/com/dylabs/zuko/dto/request/UpdateUserRequest.java
@@ -1,5 +1,6 @@
 package com.dylabs.zuko.dto.request;
 
+import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 import jakarta.validation.constraints.Email;
 
@@ -13,5 +14,9 @@ public record UpdateUserRequest(
         @Size(max = 255, message = "La descripción no puede exceder los 255 caracteres")
         String description,
 
-        String url_image // Este también es opcional
+        String url_image,
+
+        @Pattern(regexp = "^(?=.*[A-Za-z])(?=.*\\d)[A-Za-z\\d!@#$%^&*()_+={}|\\[\\]\\\\:;\"'<>,.?/-]{6,}$",
+                message = "La contraseña debe contener al menos una letra, un número y puede contener símbolos.")
+        String password
 ) {}

--- a/src/main/java/com/dylabs/zuko/dto/request/UpdateUserRequest.java
+++ b/src/main/java/com/dylabs/zuko/dto/request/UpdateUserRequest.java
@@ -15,4 +15,3 @@ public record UpdateUserRequest(
 
         String url_image // Este también es opcional
 ) {}
-git

--- a/src/main/java/com/dylabs/zuko/dto/request/UpdateUserRequest.java
+++ b/src/main/java/com/dylabs/zuko/dto/request/UpdateUserRequest.java
@@ -1,0 +1,18 @@
+package com.dylabs.zuko.dto.request;
+
+import jakarta.validation.constraints.Size;
+import jakarta.validation.constraints.Email;
+
+public record UpdateUserRequest(
+        @Size(min = 3, message = "El nombre de usuario debe tener al menos tres caracteres")
+        String username,
+
+        @Email(message = "El email debe ser válido")
+        String email,
+
+        @Size(max = 255, message = "La descripción no puede exceder los 255 caracteres")
+        String description,
+
+        String url_image // Este también es opcional
+) {}
+git

--- a/src/main/java/com/dylabs/zuko/dto/response/UserResponse.java
+++ b/src/main/java/com/dylabs/zuko/dto/response/UserResponse.java
@@ -1,6 +1,6 @@
 package com.dylabs.zuko.dto.response;
 
-public record UserResponse(
+public record  UserResponse(
         Long id,
         String username,
         String email,

--- a/src/main/java/com/dylabs/zuko/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/dylabs/zuko/exception/GlobalExceptionHandler.java
@@ -1,5 +1,6 @@
 package com.dylabs.zuko.exception;
 
+import com.dylabs.zuko.dto.ApiResponse;
 import com.dylabs.zuko.exception.roleExeptions.*;
 import com.dylabs.zuko.exception.userExeptions.*;
 import com.dylabs.zuko.exception.genreExeptions.GenreAlreadyExistsException;
@@ -7,12 +8,15 @@ import com.dylabs.zuko.exception.genreExeptions.GenreNotFoundException;
 import com.dylabs.zuko.exception.userExeptions.UserAlreadyExistsException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ProblemDetail;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 import java.net.URI;
 import java.time.Instant;
+import java.util.List;
 import java.util.stream.Collectors;
 
 @RestControllerAdvice
@@ -100,4 +104,5 @@ public class GlobalExceptionHandler {
         problem.setProperty("timestamp", Instant.now());
         return problem;
     }
+
 }

--- a/src/main/java/com/dylabs/zuko/model/User.java
+++ b/src/main/java/com/dylabs/zuko/model/User.java
@@ -25,7 +25,7 @@ public class User {
     @Column( nullable = false)
     private String password;
 
-    @Column(unique = true, nullable = true)
+    @Column(nullable = true)
     private String url_image;
 
     @Column(nullable = true)

--- a/src/main/java/com/dylabs/zuko/service/UserService.java
+++ b/src/main/java/com/dylabs/zuko/service/UserService.java
@@ -2,6 +2,7 @@ package com.dylabs.zuko.service;
 
 import com.dylabs.zuko.dto.request.CreateUserRequest;
 import com.dylabs.zuko.dto.request.LoginRequest;
+import com.dylabs.zuko.dto.request.UpdateUserRequest;
 import com.dylabs.zuko.dto.response.UserResponse;
 import com.dylabs.zuko.exception.userExeptions.IncorretPasswordExeption;
 import com.dylabs.zuko.exception.userExeptions.IncorretPasswordExeption;
@@ -95,6 +96,39 @@ public class UserService {
         User user = userRepository.findById(id)
                 .orElseThrow(() -> new UserNotFoundExeption("Usuario con ID " + id + " no encontrado"));
         return userMapper.toResponse(user);
+    }
+
+    public UserResponse updateUser(Long id, UpdateUserRequest updateRequest) {
+        User user = userRepository.findById(id)
+                .orElseThrow(() -> new UserNotFoundExeption("Usuario no encontrado con id: " + id));
+
+        // Actualizar solo los campos que no son null o vacíos
+        if (updateRequest.username() != null) {
+            user.setUsername(updateRequest.username());
+        }
+        if (updateRequest.email() != null) {
+            user.setEmail(updateRequest.email());
+        }
+        if (updateRequest.description() != null) {
+            user.setDescription(updateRequest.description());
+        }
+        if (updateRequest.url_image() != null) {
+            user.setUrl_image(updateRequest.url_image());
+        }
+
+        // Guardar el usuario actualizado
+        User updatedUser = userRepository.save(user);
+
+        // Mapear el usuario actualizado al DTO de respuesta
+        return new UserResponse(
+                updatedUser.getId(),
+                updatedUser.getUsername(),
+                updatedUser.getEmail(),
+                updatedUser.getDescription(),
+                updatedUser.getUrl_image(),
+                updatedUser.getUserRoleName(),
+                updatedUser.getIsActive()
+        );
     }
 
 }

--- a/src/main/java/com/dylabs/zuko/service/UserService.java
+++ b/src/main/java/com/dylabs/zuko/service/UserService.java
@@ -50,9 +50,10 @@ public class UserService {
             throw new UserAlreadyExistsException("El correo electrónico ya está registrado.");
         }
 
-        // 1. Verifica si el rol existe
-        Role userRole = roleRepository.findByRoleNameIgnoreCase(request.roleName())
-                .orElseThrow(() -> new RoleNotFoundException("El rol '" + request.roleName() + "' no existe."));
+        // 1. Verifica si el rol existe, asignando por defecto 'User' si no se especifica.
+        String roleName = (request.roleName() != null) ? request.roleName() : "User"; // Valor por defecto
+        Role userRole = roleRepository.findByRoleNameIgnoreCase(roleName)
+                .orElseThrow(() -> new RoleNotFoundException("El rol '" + roleName + "' no existe."));
 
         // 2. Mapea el request a entidad
         User user = userMapper.toUserEntity(request);
@@ -61,7 +62,11 @@ public class UserService {
         user.setUserRole(userRole);
 
         // 4. Establece el estado activo por defecto
-        user.setActive(true);
+        if (request.isActive() == null) {  // si no se envió el valor de isActive en la solicitud
+            user.setActive(true);  // establecer como true por defecto
+        } else {
+            user.setActive(request.isActive());  // si se envió, tomamos el valor que se especificó
+        }
 
         // 5. Guarda y responde
         User savedUser = userRepository.save(user);
@@ -114,6 +119,9 @@ public class UserService {
         }
         if (updateRequest.url_image() != null) {
             user.setUrl_image(updateRequest.url_image());
+        }
+        if (updateRequest.password() != null) {
+            user.setPassword(updateRequest.password());
         }
 
         // Guardar el usuario actualizado


### PR DESCRIPTION
Se agregó el endpoint PATCH /users/{id}, que permite actualizar los detalles del perfil de un usuario utilizando su ID.

La funcionalidad permite modificar campos específicos como nombre de usuario, correo electrónico, descripción, URL de imagen y contraseña.

Solo los campos enviados en la solicitud se actualizan, sin requerir que se envíen todos los campos.

Si algún campo no es enviado en la solicitud, se deja sin cambios en la base de datos.

Se validan los datos de entrada (como el formato del correo electrónico y la contraseña) antes de realizar la actualización.