### PR TITLE
US 08 - Editar perfil del artista

### DIFF
--- a/src/main/java/com/dylabs/zuko/controller/ArtistController.java
+++ b/src/main/java/com/dylabs/zuko/controller/ArtistController.java
@@ -4,6 +4,7 @@ import com.dylabs.zuko.dto.ApiResponse;
 import com.dylabs.zuko.dto.request.CreateArtistRequest;
 import com.dylabs.zuko.dto.response.ArtistResponse;
 import com.dylabs.zuko.service.ArtistService;
+import com.dylabs.zuko.dto.request.UpdateArtistRequest;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -25,5 +26,14 @@ public class ArtistController {
     ) {
         ArtistResponse response = artistService.createArtist(request, username);
         return new ResponseEntity<>(new ApiResponse<>("Artista creado exitosamente", response), HttpStatus.CREATED);
+    }
+
+    @PutMapping("/{id}")
+    public ResponseEntity<ArtistResponse> updateArtist(
+            @PathVariable Long id,
+            @Valid @RequestBody UpdateArtistRequest request
+    ) {
+        ArtistResponse updated = artistService.updateArtist(id, request);
+        return ResponseEntity.ok(updated);
     }
 }

--- a/src/main/java/com/dylabs/zuko/dto/request/UpdateArtistRequest.java
+++ b/src/main/java/com/dylabs/zuko/dto/request/UpdateArtistRequest.java
@@ -1,0 +1,13 @@
+package com.dylabs.zuko.dto.request;
+
+import jakarta.validation.constraints.Size;
+
+public record UpdateArtistRequest(
+        @Size(min = 3, message = "El nombre debe tener al menos 3 caracteres")
+        String name,
+
+        String country,
+
+        @Size(max = 1000, message = "La biografía no puede tener más de 1000 caracteres")
+        String biography
+) {}

--- a/src/main/java/com/dylabs/zuko/service/ArtistService.java
+++ b/src/main/java/com/dylabs/zuko/service/ArtistService.java
@@ -4,6 +4,7 @@ import com.dylabs.zuko.dto.request.CreateArtistRequest;
 import com.dylabs.zuko.dto.response.ArtistResponse;
 import com.dylabs.zuko.exception.artistExeptions.ArtistAlreadyExistsException;
 import com.dylabs.zuko.exception.artistExeptions.ArtistNotFoundException;
+import com.dylabs.zuko.dto.request.UpdateArtistRequest;
 import com.dylabs.zuko.mapper.ArtistMapper;
 import com.dylabs.zuko.model.Artist;
 import com.dylabs.zuko.repository.ArtistRepository;
@@ -40,6 +41,33 @@ public class ArtistService {
         Artist savedArtist = artistRepository.save(artist);
 
         return artistMapper.toResponse(savedArtist);
+    }
+    public ArtistResponse updateArtist(Long id, UpdateArtistRequest request) {
+        Artist artist = artistRepository.findById(id)
+                .orElseThrow(() -> new ArtistNotFoundException("Artista no encontrado con ID: " + id));
+
+        // Validar si el nombre ya está en uso por otro artista
+        if (request.name() != null && !request.name().equals(artist.getName())) {
+            artistRepository.findByName(request.name()).ifPresent(existingArtist -> {
+                throw new ArtistAlreadyExistsException("El nombre del artista ya está en uso.");
+            });
+            artist.setName(request.name());
+        }
+
+        if (request.name() != null) {
+            artist.setName(request.name());
+        }
+
+        if (request.country() != null) {
+            artist.setCountry(request.country());
+        }
+
+        if (request.biography() != null) {
+            artist.setBiography(request.biography());
+        }
+
+        Artist updatedArtist = artistRepository.save(artist);
+        return artistMapper.toResponse(updatedArtist);
     }
 
 }


### PR DESCRIPTION
- Se agregó el endpoint PUT/api/v1/artists/{id} para actualizar los datos del artista.
- La funcionalidad permite modificar campos específicos como nombre de nombre, país y bibliografía.
- Si se cambia el nombre, este no debe estar en uso por otro artista.