### PR TITLE
US 26 - Cambiar estado de actividad del artista

### DIFF
--- a/src/main/java/com/dylabs/zuko/controller/ArtistController.java
+++ b/src/main/java/com/dylabs/zuko/controller/ArtistController.java
@@ -50,4 +50,10 @@ public class ArtistController {
         var artist = artistService.getArtistById(id);
         return ResponseEntity.ok(new ApiResponse<>("Artista encontrado", artist));
     }
+
+    @PatchMapping("/{id}/toggle-active")
+    public ResponseEntity<String> toggleArtistActiveStatus(@PathVariable Long id) {
+        artistService.toggleArtistActiveStatus(id);
+        return ResponseEntity.ok("Estado de actividad del artista actualizado correctamente.");
+    }
 }

--- a/src/main/java/com/dylabs/zuko/controller/ArtistController.java
+++ b/src/main/java/com/dylabs/zuko/controller/ArtistController.java
@@ -4,6 +4,7 @@ import com.dylabs.zuko.dto.ApiResponse;
 import com.dylabs.zuko.dto.request.CreateArtistRequest;
 import com.dylabs.zuko.dto.response.ArtistResponse;
 import com.dylabs.zuko.service.ArtistService;
+import com.dylabs.zuko.dto.request.UpdateArtistRequest;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -25,5 +26,14 @@ public class ArtistController {
     ) {
         ArtistResponse response = artistService.createArtist(request, username);
         return new ResponseEntity<>(new ApiResponse<>("Artista creado exitosamente", response), HttpStatus.CREATED);
+    }
+
+    @PutMapping("/{id}")
+    public ResponseEntity<ArtistResponse> updateArtist(
+            @PathVariable Long id,
+            @Valid @RequestBody UpdateArtistRequest request
+    ) {
+        ArtistResponse updated = artistService.updateArtist(id, request);
+        return ResponseEntity.ok(updated);
     }
 }

--- a/src/main/java/com/dylabs/zuko/controller/ArtistController.java
+++ b/src/main/java/com/dylabs/zuko/controller/ArtistController.java
@@ -11,6 +11,8 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
+
 @RestController
 @RequestMapping("artists")
 @RequiredArgsConstructor
@@ -35,5 +37,17 @@ public class ArtistController {
     ) {
         ArtistResponse updated = artistService.updateArtist(id, request);
         return ResponseEntity.ok(updated);
+    }
+
+    @GetMapping
+    public ResponseEntity<ApiResponse<List<ArtistResponse>>> getAllArtists() {
+        var artists = artistService.getAllArtists();
+        return ResponseEntity.ok(new ApiResponse<>("Lista de artistas", artists));
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<ApiResponse<ArtistResponse>> getArtistById(@PathVariable Long id) {
+        var artist = artistService.getArtistById(id);
+        return ResponseEntity.ok(new ApiResponse<>("Artista encontrado", artist));
     }
 }

--- a/src/main/java/com/dylabs/zuko/dto/request/UpdateArtistRequest.java
+++ b/src/main/java/com/dylabs/zuko/dto/request/UpdateArtistRequest.java
@@ -1,0 +1,13 @@
+package com.dylabs.zuko.dto.request;
+
+import jakarta.validation.constraints.Size;
+
+public record UpdateArtistRequest(
+        @Size(min = 3, message = "El nombre debe tener al menos 3 caracteres")
+        String name,
+
+        String country,
+
+        @Size(max = 1000, message = "La biografía no puede tener más de 1000 caracteres")
+        String biography
+) {}

--- a/src/main/java/com/dylabs/zuko/dto/response/ArtistResponse.java
+++ b/src/main/java/com/dylabs/zuko/dto/response/ArtistResponse.java
@@ -5,5 +5,6 @@ public record ArtistResponse(
         String name,
         String country,
         String biography,
-        Long userId
+        Long userId,
+        boolean isActive
 ) {}

--- a/src/main/java/com/dylabs/zuko/mapper/ArtistMapper.java
+++ b/src/main/java/com/dylabs/zuko/mapper/ArtistMapper.java
@@ -18,6 +18,7 @@ public class ArtistMapper {
                 .country(request.country())
                 .biography(request.biography())
                 .user(user)
+                .isActive(true)
                 .build();
     }
 

--- a/src/main/java/com/dylabs/zuko/mapper/ArtistMapper.java
+++ b/src/main/java/com/dylabs/zuko/mapper/ArtistMapper.java
@@ -6,6 +6,9 @@ import com.dylabs.zuko.model.Artist;
 import com.dylabs.zuko.model.User;
 import org.springframework.stereotype.Component;
 
+import java.util.List;
+import java.util.stream.Collectors;
+
 @Component
 public class ArtistMapper {
 
@@ -26,5 +29,10 @@ public class ArtistMapper {
                 artist.getBiography(),
                 artist.getUser().getId()
         );
+    }
+    public List<ArtistResponse> toResponseList(List<Artist> artists) {
+        return artists.stream()
+                .map(this::toResponse)
+                .collect(Collectors.toList());
     }
 }

--- a/src/main/java/com/dylabs/zuko/mapper/ArtistMapper.java
+++ b/src/main/java/com/dylabs/zuko/mapper/ArtistMapper.java
@@ -27,7 +27,8 @@ public class ArtistMapper {
                 artist.getName(),
                 artist.getCountry(),
                 artist.getBiography(),
-                artist.getUser().getId()
+                artist.getUser().getId(),
+                artist.getIsActive()
         );
     }
     public List<ArtistResponse> toResponseList(List<Artist> artists) {

--- a/src/main/java/com/dylabs/zuko/model/Artist.java
+++ b/src/main/java/com/dylabs/zuko/model/Artist.java
@@ -28,6 +28,9 @@ public class Artist {
     @JoinColumn(name = "user_id", nullable = false, unique = true)
     private User user;
 
+    @Column(nullable = false)
+    private Boolean isActive;
+
     // Getters
 
     public Long getId() {
@@ -50,6 +53,8 @@ public class Artist {
         return user;
     }
 
+    public Boolean getIsActive() { return isActive; }
+
     // Setters
 
     public void setId(Long id) {
@@ -71,4 +76,6 @@ public class Artist {
     public void setUser(User user) {
         this.user = user;
     }
+
+    public void setIsActive(Boolean isActive) { this.isActive = isActive; }
 }

--- a/src/main/java/com/dylabs/zuko/model/Artist.java
+++ b/src/main/java/com/dylabs/zuko/model/Artist.java
@@ -29,7 +29,7 @@ public class Artist {
     private User user;
 
     @Column(nullable = false, columnDefinition = "boolean default true")
-    private Boolean isActive;
+    private Boolean isActive= true;
 
     // Getters
 

--- a/src/main/java/com/dylabs/zuko/model/Artist.java
+++ b/src/main/java/com/dylabs/zuko/model/Artist.java
@@ -28,7 +28,7 @@ public class Artist {
     @JoinColumn(name = "user_id", nullable = false, unique = true)
     private User user;
 
-    @Column(nullable = false)
+    @Column(nullable = false, columnDefinition = "boolean default true")
     private Boolean isActive;
 
     // Getters

--- a/src/main/java/com/dylabs/zuko/service/ArtistService.java
+++ b/src/main/java/com/dylabs/zuko/service/ArtistService.java
@@ -40,6 +40,8 @@ public class ArtistService {
 
         // 4. Mapear y guardar el nuevo artista
         Artist artist = artistMapper.toEntity(request, currentUser);
+        artist.setIsActive(true);
+
         Artist savedArtist = artistRepository.save(artist);
 
         return artistMapper.toResponse(savedArtist);

--- a/src/main/java/com/dylabs/zuko/service/ArtistService.java
+++ b/src/main/java/com/dylabs/zuko/service/ArtistService.java
@@ -13,6 +13,8 @@ import com.dylabs.zuko.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.util.List;
+
 @Service
 @RequiredArgsConstructor
 public class ArtistService {
@@ -68,6 +70,18 @@ public class ArtistService {
 
         Artist updatedArtist = artistRepository.save(artist);
         return artistMapper.toResponse(updatedArtist);
+    }
+    // Obtener todos los artistas
+    public List<ArtistResponse> getAllArtists() {
+        List<Artist> artists = artistRepository.findAll();
+        return artistMapper.toResponseList(artists);
+    }
+
+    // Obtener un artista por ID
+    public ArtistResponse getArtistById(Long id) {
+        Artist artist = artistRepository.findById(id)
+                .orElseThrow(() -> new ArtistNotFoundException("Artista no encontrado con ID: " + id));
+        return artistMapper.toResponse(artist);
     }
 
 }

--- a/src/main/java/com/dylabs/zuko/service/ArtistService.java
+++ b/src/main/java/com/dylabs/zuko/service/ArtistService.java
@@ -84,4 +84,13 @@ public class ArtistService {
         return artistMapper.toResponse(artist);
     }
 
+    public void toggleArtistActiveStatus(Long id) {
+        Artist artist = artistRepository.findById(id)
+                .orElseThrow(() -> new ArtistNotFoundException("Artista no encontrado con ID: " + id));
+        artist.setIsActive(!artist.getIsActive()); // Cambiar de true a false o viceversa
+        artistRepository.save(artist);
+    }
+
+
+
 }

--- a/src/main/java/com/dylabs/zuko/service/ArtistService.java
+++ b/src/main/java/com/dylabs/zuko/service/ArtistService.java
@@ -85,10 +85,18 @@ public class ArtistService {
     }
 
     public void toggleArtistActiveStatus(Long id) {
+        // 1. Buscar el artista por su ID
         Artist artist = artistRepository.findById(id)
                 .orElseThrow(() -> new ArtistNotFoundException("Artista no encontrado con ID: " + id));
-        artist.setIsActive(!artist.getIsActive()); // Cambiar de true a false o viceversa
-        artistRepository.save(artist);
+
+        // 2. Obtener el usuario asociado al artista
+        User user = artist.getUser();
+
+        // 3. Alternar el estado de isActive del usuario
+        user.setActive(!user.getIsActive());
+
+        // 4. Guardar el usuario con el nuevo estado
+        userRepository.save(user);
     }
 
 

--- a/src/main/java/com/dylabs/zuko/service/ArtistService.java
+++ b/src/main/java/com/dylabs/zuko/service/ArtistService.java
@@ -4,6 +4,7 @@ import com.dylabs.zuko.dto.request.CreateArtistRequest;
 import com.dylabs.zuko.dto.response.ArtistResponse;
 import com.dylabs.zuko.exception.artistExeptions.ArtistAlreadyExistsException;
 import com.dylabs.zuko.exception.artistExeptions.ArtistNotFoundException;
+import com.dylabs.zuko.dto.request.UpdateArtistRequest;
 import com.dylabs.zuko.mapper.ArtistMapper;
 import com.dylabs.zuko.model.Artist;
 import com.dylabs.zuko.repository.ArtistRepository;
@@ -40,6 +41,33 @@ public class ArtistService {
         Artist savedArtist = artistRepository.save(artist);
 
         return artistMapper.toResponse(savedArtist);
+    }
+    public ArtistResponse updateArtist(Long id, UpdateArtistRequest request) {
+        Artist artist = artistRepository.findById(id)
+                .orElseThrow(() -> new ArtistNotFoundException("Artista no encontrado con ID: " + id));
+
+        // Validar si el nombre ya está en uso por otro artista
+        if (request.name() != null && !request.name().equals(artist.getName())) {
+            artistRepository.findByName(request.name()).ifPresent(existingArtist -> {
+                throw new ArtistAlreadyExistsException("El nombre del artista ya está en uso.");
+            });
+            artist.setName(request.name());
+        }
+
+        if (request.name() != null) {
+            artist.setName(request.name());
+        }
+
+        if (request.country() != null) {
+            artist.setCountry(request.country());
+        }
+
+        if (request.biography() != null) {
+            artist.setBiography(request.biography());
+        }
+
+        Artist updatedArtist = artistRepository.save(artist);
+        return artistMapper.toResponse(updatedArtist);
     }
 
 }


### PR DESCRIPTION
- Se agregó el endpoint PATCH/api/v1/artists/{id}/toggle-active para cambiar la actividad del artista.
- Se gestionó la lógica para actualizar el campo isActive del artista y guardar el cambio en la base de datos.
- La respuesta del endpoint es una confirmación de que el estado del artista fue actualizado correctamente.