### PR TITLE
Feat: Arreglar manejo de excepciones a GlobalExceptionHandler

### DIFF
--- a/src/main/java/com/dylabs/zuko/controller/AlbumController.java
+++ b/src/main/java/com/dylabs/zuko/controller/AlbumController.java
@@ -2,10 +2,6 @@ package com.dylabs.zuko.controller;
 
 import com.dylabs.zuko.dto.request.AlbumRequest;
 import com.dylabs.zuko.dto.response.AlbumResponse;
-import com.dylabs.zuko.exception.albumExceptions.AlbumAlreadyExistsException;
-import com.dylabs.zuko.exception.albumExceptions.AlbumNotFoundException;
-import com.dylabs.zuko.exception.artistExeptions.ArtistNotFoundException;
-import com.dylabs.zuko.exception.genreExeptions.GenreNotFoundException;
 import com.dylabs.zuko.service.AlbumService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -64,32 +60,5 @@ public class AlbumController {
                         "message", "Álbum eliminado correctamente"
                 )
         );
-    }
-
-    // Manejo de excepciones específicas
-
-    @ExceptionHandler(AlbumAlreadyExistsException.class)
-    public ResponseEntity<String> handleAlbumAlreadyExists(AlbumAlreadyExistsException ex) {
-        return ResponseEntity.status(HttpStatus.CONFLICT).body(ex.getMessage());
-    }
-
-    @ExceptionHandler(ArtistNotFoundException.class)
-    public ResponseEntity<String> handleArtistNotFound(ArtistNotFoundException ex) {
-        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(ex.getMessage());
-    }
-
-    @ExceptionHandler(GenreNotFoundException.class)
-    public ResponseEntity<String> handleGenreNotFound(GenreNotFoundException ex) {
-        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(ex.getMessage());
-    }
-
-    @ExceptionHandler(AlbumNotFoundException.class)
-    public ResponseEntity<String> handleAlbumNotFound(AlbumNotFoundException ex) {
-        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(ex.getMessage());
-    }
-
-    @ExceptionHandler(IllegalArgumentException.class)
-    public ResponseEntity<String> handleIllegalArgument(IllegalArgumentException ex) {
-        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(ex.getMessage());
     }
 }

--- a/src/main/java/com/dylabs/zuko/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/dylabs/zuko/exception/GlobalExceptionHandler.java
@@ -1,5 +1,7 @@
 package com.dylabs.zuko.exception;
 
+import com.dylabs.zuko.exception.albumExceptions.AlbumAlreadyExistsException;
+import com.dylabs.zuko.exception.albumExceptions.AlbumNotFoundException;
 import com.dylabs.zuko.exception.roleExeptions.*;
 import com.dylabs.zuko.exception.songExceptions.SongAlreadyExistException;
 import com.dylabs.zuko.exception.songExceptions.SongNotFoundException;
@@ -139,4 +141,32 @@ public class GlobalExceptionHandler {
         problem.setProperty("timestamp", Instant.now());
         return problem;
     }
+
+    @ExceptionHandler(AlbumAlreadyExistsException.class)
+    public ProblemDetail handleAlbumAlreadyExists(AlbumAlreadyExistsException ex) {
+        ProblemDetail problem = ProblemDetail.forStatusAndDetail(HttpStatus.CONFLICT, ex.getMessage());
+        problem.setTitle("Álbum duplicado");
+        problem.setType(URI.create("/errors/album-exists"));
+        problem.setProperty("timestamp", Instant.now());
+        return problem;
+    }
+
+    @ExceptionHandler(AlbumNotFoundException.class)
+    public ProblemDetail handleAlbumNotFound(AlbumNotFoundException ex) {
+        ProblemDetail problem = ProblemDetail.forStatusAndDetail(HttpStatus.NOT_FOUND, ex.getMessage());
+        problem.setTitle("Álbum no encontrado");
+        problem.setType(URI.create("/errors/album-not-found"));
+        problem.setProperty("timestamp", Instant.now());
+        return problem;
+    }
+
+    @ExceptionHandler(IllegalArgumentException.class)
+    public ProblemDetail handleIllegalArgument(IllegalArgumentException ex) {
+        ProblemDetail problem = ProblemDetail.forStatusAndDetail(HttpStatus.BAD_REQUEST, ex.getMessage());
+        problem.setTitle("Error de validación");
+        problem.setType(URI.create("/errors/invalid-argument"));
+        problem.setProperty("timestamp", Instant.now());
+        return problem;
+    }
+
 }

--- a/src/main/java/com/dylabs/zuko/repository/AlbumRepository.java
+++ b/src/main/java/com/dylabs/zuko/repository/AlbumRepository.java
@@ -7,4 +7,6 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface AlbumRepository extends JpaRepository<Album, Long> {
     boolean existsByTitleIgnoreCaseAndArtistId(String title, Long artistId);
+
+    boolean existsByTitleIgnoreCaseAndArtistIdAndIdNot(String title, Long artistId, Long id);
 }

--- a/src/main/java/com/dylabs/zuko/service/AlbumService.java
+++ b/src/main/java/com/dylabs/zuko/service/AlbumService.java
@@ -99,6 +99,13 @@ public class AlbumService {
             throw new IllegalArgumentException("El álbum debe contener al menos dos canciones.");
         }
 
+        boolean existsWithSameTitle = albumRepository
+                .existsByTitleIgnoreCaseAndArtistIdAndIdNot(request.title(), artist.getId(), album.getId());
+
+        if (existsWithSameTitle) {
+            throw new AlbumAlreadyExistsException("El título del álbum ya existe para este artista.");
+        }
+
         // Usar el mapper para actualizar los campos del álbum y las canciones
         albumMapper.updateAlbumFromRequest(album, request, genre, artist); // Pasar el artista al mapper
 


### PR DESCRIPTION
Agrega método updateAlbum en AlbumService.

Se unifica manejo de errores con GlobalExceptionHandler.
Añade validaciones para:
- Verificar que el álbum exista.
- Confirmar que el artista es el creador.
- Validar que haya al menos dos canciones.
- Evitar duplicidad de títulos entre álbumes del mismo artista.

Se eliminan los @ExceptionHandler específicos del controller.