### PR TITLE
Fix album exceptions 

### DIFF
--- a/src/main/java/com/dylabs/zuko/controller/AlbumController.java
+++ b/src/main/java/com/dylabs/zuko/controller/AlbumController.java
@@ -2,10 +2,6 @@ package com.dylabs.zuko.controller;
 
 import com.dylabs.zuko.dto.request.AlbumRequest;
 import com.dylabs.zuko.dto.response.AlbumResponse;
-import com.dylabs.zuko.exception.albumExceptions.AlbumAlreadyExistsException;
-import com.dylabs.zuko.exception.albumExceptions.AlbumNotFoundException;
-import com.dylabs.zuko.exception.artistExeptions.ArtistNotFoundException;
-import com.dylabs.zuko.exception.genreExeptions.GenreNotFoundException;
 import com.dylabs.zuko.service.AlbumService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -64,32 +60,5 @@ public class AlbumController {
                         "message", "Álbum eliminado correctamente"
                 )
         );
-    }
-
-    // Manejo de excepciones específicas
-
-    @ExceptionHandler(AlbumAlreadyExistsException.class)
-    public ResponseEntity<String> handleAlbumAlreadyExists(AlbumAlreadyExistsException ex) {
-        return ResponseEntity.status(HttpStatus.CONFLICT).body(ex.getMessage());
-    }
-
-    @ExceptionHandler(ArtistNotFoundException.class)
-    public ResponseEntity<String> handleArtistNotFound(ArtistNotFoundException ex) {
-        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(ex.getMessage());
-    }
-
-    @ExceptionHandler(GenreNotFoundException.class)
-    public ResponseEntity<String> handleGenreNotFound(GenreNotFoundException ex) {
-        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(ex.getMessage());
-    }
-
-    @ExceptionHandler(AlbumNotFoundException.class)
-    public ResponseEntity<String> handleAlbumNotFound(AlbumNotFoundException ex) {
-        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(ex.getMessage());
-    }
-
-    @ExceptionHandler(IllegalArgumentException.class)
-    public ResponseEntity<String> handleIllegalArgument(IllegalArgumentException ex) {
-        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(ex.getMessage());
     }
 }

--- a/src/main/java/com/dylabs/zuko/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/dylabs/zuko/exception/GlobalExceptionHandler.java
@@ -2,6 +2,8 @@ package com.dylabs.zuko.exception;
 
 import com.dylabs.zuko.exception.albumExceptions.AlbumAlreadyExistsException;
 import com.dylabs.zuko.exception.albumExceptions.AlbumNotFoundException;
+import com.dylabs.zuko.exception.albumExceptions.AlbumPermissionException;
+import com.dylabs.zuko.exception.albumExceptions.AlbumValidationException;
 import com.dylabs.zuko.exception.roleExeptions.*;
 import com.dylabs.zuko.exception.songExceptions.SongAlreadyExistException;
 import com.dylabs.zuko.exception.songExceptions.SongNotFoundException;
@@ -160,13 +162,21 @@ public class GlobalExceptionHandler {
         return problem;
     }
 
-    @ExceptionHandler(IllegalArgumentException.class)
-    public ProblemDetail handleIllegalArgument(IllegalArgumentException ex) {
-        ProblemDetail problem = ProblemDetail.forStatusAndDetail(HttpStatus.BAD_REQUEST, ex.getMessage());
-        problem.setTitle("Error de validación");
-        problem.setType(URI.create("/errors/invalid-argument"));
+    @ExceptionHandler(AlbumPermissionException.class)
+    public ProblemDetail handleAlbumPermission(AlbumPermissionException ex) {
+        ProblemDetail problem = ProblemDetail.forStatusAndDetail(HttpStatus.FORBIDDEN, ex.getMessage());
+        problem.setTitle("Permiso denegado");
+        problem.setType(URI.create("/errors/album-permission"));
         problem.setProperty("timestamp", Instant.now());
         return problem;
     }
 
+    @ExceptionHandler(AlbumValidationException.class)
+    public ProblemDetail handleAlbumValidation(AlbumValidationException ex) {
+        ProblemDetail problem = ProblemDetail.forStatusAndDetail(HttpStatus.BAD_REQUEST, ex.getMessage());
+        problem.setTitle("Error de validación");
+        problem.setType(URI.create("/errors/album-validation"));
+        problem.setProperty("timestamp", Instant.now());
+        return problem;
+    }
 }

--- a/src/main/java/com/dylabs/zuko/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/dylabs/zuko/exception/GlobalExceptionHandler.java
@@ -1,5 +1,7 @@
 package com.dylabs.zuko.exception;
 
+import com.dylabs.zuko.exception.albumExceptions.AlbumAlreadyExistsException;
+import com.dylabs.zuko.exception.albumExceptions.AlbumNotFoundException;
 import com.dylabs.zuko.exception.roleExeptions.*;
 import com.dylabs.zuko.exception.songExceptions.SongAlreadyExistException;
 import com.dylabs.zuko.exception.songExceptions.SongNotFoundException;
@@ -139,4 +141,32 @@ public class GlobalExceptionHandler {
         problem.setProperty("timestamp", Instant.now());
         return problem;
     }
+
+    @ExceptionHandler(AlbumAlreadyExistsException.class)
+    public ProblemDetail handleAlbumAlreadyExists(AlbumAlreadyExistsException ex) {
+        ProblemDetail problem = ProblemDetail.forStatusAndDetail(HttpStatus.CONFLICT, ex.getMessage());
+        problem.setTitle("Álbum duplicado");
+        problem.setType(URI.create("/errors/album-exists"));
+        problem.setProperty("timestamp", Instant.now());
+        return problem;
+    }
+
+    @ExceptionHandler(AlbumNotFoundException.class)
+    public ProblemDetail handleAlbumNotFound(AlbumNotFoundException ex) {
+        ProblemDetail problem = ProblemDetail.forStatusAndDetail(HttpStatus.NOT_FOUND, ex.getMessage());
+        problem.setTitle("Álbum no encontrado");
+        problem.setType(URI.create("/errors/album-not-found"));
+        problem.setProperty("timestamp", Instant.now());
+        return problem;
+    }
+
+    @ExceptionHandler(IllegalArgumentException.class)
+    public ProblemDetail handleIllegalArgument(IllegalArgumentException ex) {
+        ProblemDetail problem = ProblemDetail.forStatusAndDetail(HttpStatus.BAD_REQUEST, ex.getMessage());
+        problem.setTitle("Error de validación");
+        problem.setType(URI.create("/errors/invalid-argument"));
+        problem.setProperty("timestamp", Instant.now());
+        return problem;
+    }
+
 }

--- a/src/main/java/com/dylabs/zuko/exception/albumExceptions/AlbumNotFoundException.java
+++ b/src/main/java/com/dylabs/zuko/exception/albumExceptions/AlbumNotFoundException.java
@@ -1,7 +1,5 @@
 package com.dylabs.zuko.exception.albumExceptions;
 
 public class AlbumNotFoundException extends RuntimeException {
-  public AlbumNotFoundException(String message) {
-    super(message);
-  }
+  public AlbumNotFoundException(String message) { super(message); }
 }

--- a/src/main/java/com/dylabs/zuko/exception/albumExceptions/AlbumPermissionException.java
+++ b/src/main/java/com/dylabs/zuko/exception/albumExceptions/AlbumPermissionException.java
@@ -1,0 +1,5 @@
+package com.dylabs.zuko.exception.albumExceptions;
+
+public class AlbumPermissionException extends RuntimeException {
+  public AlbumPermissionException(String message) { super(message); }
+}

--- a/src/main/java/com/dylabs/zuko/exception/albumExceptions/AlbumValidationException.java
+++ b/src/main/java/com/dylabs/zuko/exception/albumExceptions/AlbumValidationException.java
@@ -1,0 +1,7 @@
+package com.dylabs.zuko.exception.albumExceptions;
+
+public class AlbumValidationException extends RuntimeException {
+    public AlbumValidationException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/dylabs/zuko/repository/AlbumRepository.java
+++ b/src/main/java/com/dylabs/zuko/repository/AlbumRepository.java
@@ -7,4 +7,6 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface AlbumRepository extends JpaRepository<Album, Long> {
     boolean existsByTitleIgnoreCaseAndArtistId(String title, Long artistId);
+
+    boolean existsByTitleIgnoreCaseAndArtistIdAndIdNot(String title, Long artistId, Long id);
 }

--- a/src/main/java/com/dylabs/zuko/service/AlbumService.java
+++ b/src/main/java/com/dylabs/zuko/service/AlbumService.java
@@ -99,6 +99,13 @@ public class AlbumService {
             throw new IllegalArgumentException("El álbum debe contener al menos dos canciones.");
         }
 
+        boolean existsWithSameTitle = albumRepository
+                .existsByTitleIgnoreCaseAndArtistIdAndIdNot(request.title(), artist.getId(), album.getId());
+
+        if (existsWithSameTitle) {
+            throw new AlbumAlreadyExistsException("El título del álbum ya existe para este artista.");
+        }
+
         // Usar el mapper para actualizar los campos del álbum y las canciones
         albumMapper.updateAlbumFromRequest(album, request, genre, artist); // Pasar el artista al mapper
 

--- a/src/main/java/com/dylabs/zuko/service/AlbumService.java
+++ b/src/main/java/com/dylabs/zuko/service/AlbumService.java
@@ -4,6 +4,8 @@ import com.dylabs.zuko.dto.request.AlbumRequest;
 import com.dylabs.zuko.dto.response.AlbumResponse;
 import com.dylabs.zuko.exception.albumExceptions.AlbumAlreadyExistsException;
 import com.dylabs.zuko.exception.albumExceptions.AlbumNotFoundException;
+import com.dylabs.zuko.exception.albumExceptions.AlbumPermissionException;
+import com.dylabs.zuko.exception.albumExceptions.AlbumValidationException;
 import com.dylabs.zuko.exception.artistExeptions.ArtistNotFoundException;
 import com.dylabs.zuko.exception.genreExeptions.GenreNotFoundException;
 import com.dylabs.zuko.mapper.AlbumMapper;
@@ -48,7 +50,7 @@ public class AlbumService {
 
         // Validar que el álbum contenga al menos dos canciones
         if (request.songs() == null || request.songs().size() < 2) {
-            throw new IllegalArgumentException("El álbum debe contener al menos dos canciones.");
+            throw new AlbumValidationException("El álbum debe contener al menos dos canciones.");
         }
 
         // Convertir el DTO de solicitud a entidad de álbum
@@ -87,7 +89,7 @@ public class AlbumService {
 
         // Verificar que el artista que intenta editar el álbum sea el mismo que el creador
         if (!album.getArtist().getId().equals(artist.getId())) {
-            throw new IllegalArgumentException("No tienes permiso para editar este álbum.");
+            throw new AlbumPermissionException("No tienes permiso para editar este álbum.");
         }
 
         // Buscar el género
@@ -96,9 +98,10 @@ public class AlbumService {
 
         // Validar que el álbum contenga al menos dos canciones
         if (request.songs() == null || request.songs().size() < 2) {
-            throw new IllegalArgumentException("El álbum debe contener al menos dos canciones.");
+            throw new AlbumValidationException("El álbum debe contener al menos dos canciones.");
         }
 
+        // Validar que al editar el nombre del álbum no coincida con uno ya existente
         boolean existsWithSameTitle = albumRepository
                 .existsByTitleIgnoreCaseAndArtistIdAndIdNot(request.title(), artist.getId(), album.getId());
 
@@ -124,7 +127,7 @@ public class AlbumService {
                 .orElseThrow(() -> new ArtistNotFoundException("El artista no fue encontrado."));
 
         if (!album.getArtist().getId().equals(artist.getId())) {
-            throw new IllegalArgumentException("No tienes permiso para eliminar este álbum.");
+            throw new AlbumPermissionException("No tienes permiso para eliminar este álbum.");
         }
 
         albumRepository.delete(album);


### PR DESCRIPTION
Este PR implementa las siguientes mejoras y correcciones en la funcionalidad de álbumes:

Reemplazo de IllegalArgumentException por excepciones personalizadas:
- Se lanza AlbumPermissionException cuando un artista intenta editar o eliminar un álbum que no le pertenece.
- Se lanza AlbumValidationException cuando se intenta crear o actualizar un álbum con menos de dos canciones.

Centralización del manejo de errores:
- Se eliminó el manejo directo de excepciones en el controller.
- Se delega todo al GlobalExceptionHandler, siguiendo el estándar del equipo.

Validación de título único al editar álbumes:
- Se agregó una verificación para evitar duplicación de títulos entre álbumes del mismo artista.