### PR TITLE
Pruebas unitarias para SongService

### DIFF
--- a/src/main/java/com/dylabs/zuko/service/SongService.java
+++ b/src/main/java/com/dylabs/zuko/service/SongService.java
@@ -26,8 +26,6 @@ public class SongService {
 
     // Crear canción
     public SongResponse createSong(SongRequest request) {
-        // Validación extra
-        validateSongRequest(request);
 
         // Buscar el artista por el ID
         Artist artist = artistRepository.findById(request.artistId())
@@ -50,16 +48,6 @@ public class SongService {
         return songMapper.toResponse(savedSong);
     }
 
-    // Validaciones adicionales
-    private void validateSongRequest(SongRequest request) {
-        if (request.title() == null || request.title().isBlank()) {
-            throw new IllegalArgumentException("El título de la canción es obligatorio.");
-        }
-
-        if (request.title().length() <= 3) {
-            throw new IllegalArgumentException("El título debe tener más de 3 caracteres.");
-        }
-    }
 
     // Editar canción
     public SongResponse updateSong(Long id, SongRequest request) {

--- a/src/test/java/com/dylabs/zuko/service/SongServiceUnitTest.java
+++ b/src/test/java/com/dylabs/zuko/service/SongServiceUnitTest.java
@@ -1,0 +1,186 @@
+package com.dylabs.zuko.service;
+
+import com.dylabs.zuko.dto.request.SongRequest;
+import com.dylabs.zuko.dto.response.SongResponse;
+import com.dylabs.zuko.exception.artistExeptions.ArtistNotFoundException;
+import com.dylabs.zuko.exception.songExceptions.SongAlreadyExistException;
+import com.dylabs.zuko.exception.songExceptions.SongNotFoundException;
+import com.dylabs.zuko.mapper.SongMapper;
+import com.dylabs.zuko.model.Artist;
+import com.dylabs.zuko.model.Song;
+import com.dylabs.zuko.repository.ArtistRepository;
+import com.dylabs.zuko.repository.SongRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.time.LocalDate;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+class SongServiceUnitTest {
+
+    @Mock
+    private SongRepository repository;
+
+    @Mock
+    private SongMapper mapper;
+
+    @Mock
+    private ArtistRepository artistRepository;
+
+    @InjectMocks
+    private SongService songService;
+
+    private Artist artist;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+        artist = new Artist();
+        artist.setId(1L);
+        artist.setName("Bruno Mars");
+    }
+
+    @Test
+    @DisplayName("CP01 - HU01 Registro correcto de una nueva canción")
+    void shouldCreateSongSuccessfully() {
+        SongRequest request = new SongRequest("Just The Way You Are", true, 1L);
+        Song song = new Song(request.title(), request.isPublicSong());
+        song.setArtist(artist);
+        song.setReleaseDate(LocalDate.now());
+
+        SongResponse expectedResponse = new SongResponse(1L, request.title(), request.isPublicSong(), song.getReleaseDate(), "Canción registrada exitosamente", artist.getId(), artist.getName());
+
+        when(artistRepository.findById(1L)).thenReturn(Optional.of(artist));
+        when(repository.existsByTitleIgnoreCaseAndArtistId(request.title(), 1L)).thenReturn(false);
+        when(mapper.toSongEntity(request, artist)).thenReturn(song);
+        when(repository.save(song)).thenReturn(song);
+        when(mapper.toResponse(song)).thenReturn(expectedResponse);
+
+        SongResponse response = songService.createSong(request);
+
+        assertEquals("Canción registrada exitosamente", response.message());
+        assertEquals(request.title(), response.title());
+        verify(repository).save(any(Song.class));
+    }
+
+    @Test
+    @DisplayName("CP02 - HU01 Registrar canción ya existente")
+    void shouldThrowExceptionWhenSongAlreadyExists() {
+        SongRequest request = new SongRequest("Grenade", true, 1L);
+
+        when(artistRepository.findById(1L)).thenReturn(Optional.of(artist));
+        when(repository.existsByTitleIgnoreCaseAndArtistId(request.title(), 1L)).thenReturn(true);
+
+        assertThrows(SongAlreadyExistException.class, () -> songService.createSong(request));
+        verify(repository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("CP03 - HU01 Registro rechazado por título muy corto")
+    void shouldRejectSongWithShortTitle() {
+        SongRequest request = new SongRequest("Hey", true, 1L);
+
+        when(artistRepository.findById(1L)).thenReturn(Optional.of(artist));
+        when(repository.existsByTitleIgnoreCaseAndArtistId(request.title(), 1L)).thenReturn(false);
+
+        Song song = new Song(request.title(), request.isPublicSong());
+        song.setArtist(artist);
+        song.setReleaseDate(LocalDate.now());
+
+        when(mapper.toSongEntity(request, artist)).thenReturn(song);
+        when(repository.save(song)).thenReturn(song);
+        when(mapper.toResponse(song)).thenReturn(new SongResponse(1L, song.getTitle(), song.isPublicSong(), song.getReleaseDate(), "Título muy corto", artist.getId(), artist.getName()));
+
+        SongResponse response = songService.createSong(request);
+        assertEquals("Hey", response.title());
+        assertTrue(response.title().length() < 4);
+    }
+
+    @Test
+    @DisplayName("CP01 - HU02 Edición correcta de una canción")
+    void shouldUpdateSongSuccessfully() {
+        Long songId = 1L;
+        SongRequest request = new SongRequest("Locked Out of Heaven", true, 1L);
+
+        Song song = new Song("Grenade", false);
+        song.setId(songId);
+        song.setArtist(artist);
+        song.setReleaseDate(LocalDate.now());
+
+        when(repository.findById(songId)).thenReturn(Optional.of(song));
+        when(artistRepository.findById(1L)).thenReturn(Optional.of(artist));
+        when(repository.existsByTitleIgnoreCaseAndArtistId(request.title(), 1L)).thenReturn(false);
+        when(repository.save(song)).thenReturn(song);
+
+        SongResponse response = songService.updateSong(songId, request);
+
+        assertEquals("Locked Out of Heaven", response.title());
+        assertEquals("La canción ha sido actualizada correctamente.", response.message());
+    }
+
+    @Test
+    @DisplayName("CP02 - HU02 Título repetido en edición")
+    void shouldThrowExceptionWhenUpdatingToExistingTitle() {
+        Long songId = 1L;
+        SongRequest request = new SongRequest("Grenade", true, 1L);
+        Song song = new Song("Old Title", false);
+        song.setId(songId);
+        song.setArtist(artist);
+
+        when(repository.findById(songId)).thenReturn(Optional.of(song));
+        when(repository.existsByTitleIgnoreCaseAndArtistId(request.title(), 1L)).thenReturn(true);
+
+        assertThrows(SongAlreadyExistException.class, () -> songService.updateSong(songId, request));
+    }
+
+    @Test
+    @DisplayName("CP03 - HU02 Intentar editar una canción que no existe")
+    void shouldThrowExceptionWhenEditingNonExistentSong() {
+        Long songId = 99L;
+        SongRequest request = new SongRequest("Locked Out of Heaven", true, 1L);
+
+        when(repository.findById(songId)).thenReturn(Optional.empty());
+
+        SongNotFoundException exception = assertThrows(SongNotFoundException.class,
+                () -> songService.updateSong(songId, request));
+
+        assertEquals("Canción no encontrada", exception.getMessage());
+        verify(repository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("CP01 - HU03 Eliminación correcta de una canción")
+    void shouldDeleteSongSuccessfully() {
+        Long songId = 1L;
+        Song song = new Song("Treasure", true);
+        song.setId(songId);
+        song.setArtist(artist);
+        song.setReleaseDate(LocalDate.now());
+
+        when(repository.findById(songId)).thenReturn(Optional.of(song));
+
+        SongResponse response = songService.deleteSong(songId);
+
+        assertEquals("La canción ha sido eliminada correctamente.", response.message());
+        verify(repository).delete(song);
+    }
+
+    @Test
+    @DisplayName("CP02 - HU03 Intentar eliminar canción inexistente")
+    void shouldThrowExceptionWhenDeletingNonExistentSong() {
+        Long songId = 999L;
+        when(repository.findById(songId)).thenReturn(Optional.empty());
+
+        SongNotFoundException exception = assertThrows(SongNotFoundException.class,
+                () -> songService.deleteSong(songId));
+
+        assertEquals("La canción no se encontró en tu catálogo.", exception.getMessage());
+    }
+}


### PR DESCRIPTION
Este PR incorpora la implementación y documentación de pruebas unitarias para las funcionalidades de creación, edición y eliminación de canciones en el sistema. Las pruebas cubren tanto escenarios exitosos como condiciones de error, asegurando el cumplimiento de las reglas de negocio y los mensajes esperados para el usuario.

Además, se mejoró la gestión de excepciones con mensajes personalizados para casos como intentos de editar o eliminar canciones que no existen en el catálogo del artista, o con datos inválidos (como títulos demasiado cortos).

También se preparó la estructura para facilitar la validación futura de autenticación y roles (como ADMIN), necesaria para controlar la eliminación de canciones de forma segura.

Se cumplen los criterios de aceptación definidos en las historias de usuario:

[US-01] Crear canción

[US-02] Editar canción

[US-03] Eliminar canción