### PR TITLE
Agregar seguridad y autorización en clase song con pruebas actualizadas

### DIFF
--- a/src/main/java/com/dylabs/zuko/controller/SongController.java
+++ b/src/main/java/com/dylabs/zuko/controller/SongController.java
@@ -6,6 +6,8 @@ import com.dylabs.zuko.service.SongService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -16,19 +18,27 @@ public class SongController {
     private final SongService songService;
 
     @PostMapping
-    public ResponseEntity<SongResponse> createSong(@RequestBody @Valid SongRequest request) {
-        SongResponse response = songService.createSong(request);
+    @PreAuthorize("hasRole('ADMIN') or hasRole('USER')")
+    public ResponseEntity<SongResponse> createSong(@RequestBody @Valid SongRequest request, Authentication authentication) {
+        // Obtienes el username/id del token decodificado por Spring Security
+        String username = authentication.getName();
+
+        SongResponse response = songService.createSong(request, username);
         return ResponseEntity.ok(response);
     }
 
     @PutMapping("/{id}")
-    public ResponseEntity<SongResponse> updateSong(@PathVariable Long id, @RequestBody @Valid SongRequest request) {
-        SongResponse response = songService.updateSong(id, request);
+    @PreAuthorize("hasRole('ADMIN') or hasRole('USER')")
+    public ResponseEntity<SongResponse> updateSong(@PathVariable Long id, @RequestBody @Valid SongRequest request, Authentication authentication) {
+        String username = authentication.getName();
+        SongResponse response = songService.updateSong(id, request, username);
         return ResponseEntity.ok(response);
     }
 
     @DeleteMapping("/{id}")
-    public SongResponse deleteSong(@PathVariable Long id) {
-        return songService.deleteSong(id);
+    @PreAuthorize("hasRole('ADMIN') or hasRole('USER')")
+    public SongResponse deleteSong(@PathVariable Long id, Authentication authentication) {
+        String username = authentication.getName();
+        return songService.deleteSong(id, username);
     }
 }

--- a/src/main/java/com/dylabs/zuko/service/SongService.java
+++ b/src/main/java/com/dylabs/zuko/service/SongService.java
@@ -8,9 +8,13 @@ import com.dylabs.zuko.exception.songExceptions.SongNotFoundException;
 import com.dylabs.zuko.mapper.SongMapper;
 import com.dylabs.zuko.model.Artist;
 import com.dylabs.zuko.model.Song;
+import com.dylabs.zuko.model.User;
 import com.dylabs.zuko.repository.ArtistRepository;
 import com.dylabs.zuko.repository.SongRepository;
+import com.dylabs.zuko.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDate;
@@ -23,76 +27,90 @@ public class SongService {
     private final SongRepository repository;
     private final SongMapper songMapper;
     private final ArtistRepository artistRepository;
+    private final UserRepository userRepository;
 
     // Crear canción
-    public SongResponse createSong(SongRequest request) {
+    public SongResponse createSong(SongRequest request, String userIdFromToken) {
+        User user = userRepository.findById(Long.parseLong(userIdFromToken))
+                .orElseThrow(() -> new UsernameNotFoundException("Usuario no encontrado"));
 
-        // Buscar el artista por el ID
-        Artist artist = artistRepository.findById(request.artistId())
-                .orElseThrow(() -> new ArtistNotFoundException("El artista con ID " + request.artistId() + " no existe"));
-
-        // Validar si ya existe la canción con el mismo título y el mismo artista
-        boolean exists = repository.existsByTitleIgnoreCaseAndArtistId(request.title(), request.artistId());
-        if (exists) {
-            throw new SongAlreadyExistException("La canción " + request.title() + " ya está registrada para este artista.");
+        Artist artist;
+        if (user.getUserRoleName().equals("ADMIN")) {
+            artist = artistRepository.findById(request.artistId())
+                    .orElseThrow(() -> new ArtistNotFoundException("El artista con ID " + request.artistId() + " no existe"));
+        } else {
+            artist = artistRepository.findByUserId(user.getId())
+                    .orElseThrow(() -> new ArtistNotFoundException("No tienes un perfil de artista."));
         }
 
-        // Crear una nueva canción
+        boolean exists = repository.existsByTitleIgnoreCaseAndArtistId(request.title(), artist.getId());
+        if (exists) {
+            throw new SongAlreadyExistException("La canción ya está registrada para este artista.");
+        }
+
         Song song = songMapper.toSongEntity(request, artist);
-        song.setReleaseDate(LocalDate.now()); // Aquí le asignas la fecha actual
+        song.setReleaseDate(LocalDate.now());
 
-        // Guardar la canción en la base de datos
-        Song savedSong = repository.save(song);
-
-        // Usamos el mapper para devolver la respuesta
-        return songMapper.toResponse(savedSong);
+        Song saved = repository.save(song);
+        return songMapper.toResponse(saved);
     }
 
-
     // Editar canción
-    public SongResponse updateSong(Long id, SongRequest request) {
+    public SongResponse updateSong(Long id, SongRequest request, String userIdFromToken) {
+        User user = userRepository.findById(Long.parseLong(userIdFromToken))
+                .orElseThrow(() -> new UsernameNotFoundException("Usuario no encontrado"));
+
         Song song = repository.findById(id)
                 .orElseThrow(() -> new SongNotFoundException("Canción no encontrada"));
 
-        // Verificar si el nuevo título ya existe para el mismo artista
-        boolean exists = repository.existsByTitleIgnoreCaseAndArtistId(request.title(), request.artistId());
-        if (exists) {
-            throw new SongAlreadyExistException("El título " + request.title() + " ya existe en el catálogo de este artista.");
+        if (!user.getUserRoleName().equals("ADMIN")) {
+            Artist artist = artistRepository.findByUserId(user.getId())
+                    .orElseThrow(() -> new ArtistNotFoundException("No tienes un perfil de artista."));
+            if (!song.getArtist().getId().equals(artist.getId())) {
+                throw new AccessDeniedException("No puedes modificar esta canción.");
+            }
         }
 
-        // Actualizar los datos de la canción
+        if (user.getUserRoleName().equals("ADMIN")) {
+            Artist newArtist = artistRepository.findById(request.artistId())
+                    .orElseThrow(() -> new ArtistNotFoundException("Artista no encontrado"));
+            song.setArtist(newArtist);
+        }
+
         song.setTitle(request.title());
         song.setPublicSong(request.isPublicSong());
 
-        // Buscar el artista por ID y asignarlo
-        Artist artist = artistRepository.findById(request.artistId())
-                .orElseThrow(() -> new ArtistNotFoundException("El artista con ID " + request.artistId() + " no existe"));
-        song.setArtist(artist);
+        Song updated = repository.save(song);
 
-        Song updatedSong = repository.save(song);
-
-        // Retornar la respuesta con mensaje de éxito
         return new SongResponse(
-                updatedSong.getId(),
-                updatedSong.getTitle(),
-                updatedSong.isPublicSong(),
-                updatedSong.getReleaseDate(),
+                updated.getId(),
+                updated.getTitle(),
+                updated.isPublicSong(),
+                updated.getReleaseDate(),
                 "La canción ha sido actualizada correctamente.",
-                updatedSong.getArtist().getId(),
-                updatedSong.getArtist().getName()
+                updated.getArtist().getId(),
+                updated.getArtist().getName()
         );
     }
 
     // Eliminar canción
-    public SongResponse deleteSong(Long id) {
-        // Buscar la canción por id
-        Song song = repository.findById(id)
-                .orElseThrow(() -> new SongNotFoundException("La canción no se encontró en tu catálogo."));
+    public SongResponse deleteSong(Long id, String userIdFromToken) {
+        User user = userRepository.findById(Long.parseLong(userIdFromToken))
+                .orElseThrow(() -> new UsernameNotFoundException("Usuario no encontrado"));
 
-        // Eliminar la canción
+        Song song = repository.findById(id)
+                .orElseThrow(() -> new SongNotFoundException("La canción no se encontró."));
+
+        if (!user.getUserRoleName().equals("ADMIN")) {
+            Artist artist = artistRepository.findByUserId(user.getId())
+                    .orElseThrow(() -> new ArtistNotFoundException("No tienes un perfil de artista."));
+            if (!song.getArtist().getId().equals(artist.getId())) {
+                throw new AccessDeniedException("No puedes eliminar esta canción.");
+            }
+        }
+
         repository.delete(song);
 
-        // Crear y devolver la respuesta con mensaje de éxito
         return new SongResponse(
                 song.getId(),
                 song.getTitle(),

--- a/src/test/java/com/dylabs/zuko/service/SongServiceUnitTest.java
+++ b/src/test/java/com/dylabs/zuko/service/SongServiceUnitTest.java
@@ -243,9 +243,9 @@ class SongServiceUnitTest {
         assertEquals("La canción no se encontró.", exception.getMessage());
     }
 
-    // CP02 - Editar canción ARTIST sin perfil de artista lanza excepción
+
     @Test
-    @DisplayName("CP02 - Editar canción como Artista sin perfil de artista lanza excepción")
+    @DisplayName("CP02 - Editar canción como Usuario sin perfil de artista")
     void updateSongAsArtistWithoutProfileThrows() {
         Long songId = 1L;
         SongRequest request = new SongRequest("New Title", true, 99L);
@@ -265,9 +265,8 @@ class SongServiceUnitTest {
         verify(repository, never()).save(any());
     }
 
-    // CP03 - Editar canción ARTIST no dueño lanza AccessDeniedException
     @Test
-    @DisplayName("CP03 - Editar canción como Artista no dueño lanza AccessDeniedException")
+    @DisplayName("CP03 - Editar canción como Artista pero no le pertenece la canción")
     void updateSongAsArtistNotOwnerThrows() {
         Long songId = 1L;
         SongRequest request = new SongRequest("New Title", true, 99L);
@@ -289,9 +288,9 @@ class SongServiceUnitTest {
         verify(repository, never()).save(any());
     }
 
-    // CP02 - Eliminar canción ARTIST sin perfil de artista lanza excepción
+
     @Test
-    @DisplayName("CP02 - Eliminar canción como Artista sin perfil de artista lanza excepción")
+    @DisplayName("CP02 - Eliminar canción como Usuario sin perfil de artista")
     void deleteSongAsArtistWithoutProfileThrows() {
         Long songId = 1L;
         Song song = new Song("Title", true);
@@ -310,9 +309,9 @@ class SongServiceUnitTest {
         verify(repository, never()).delete(any());
     }
 
-    // CP03 - Eliminar canción ARTIST no dueño lanza AccessDeniedException
+
     @Test
-    @DisplayName("CP03 - Eliminar canción como Artista no dueño lanza AccessDeniedException")
+    @DisplayName("CP03 - Eliminar canción como Artista pero no le pertenece la canción")
     void deleteSongAsArtistNotOwnerThrows() {
         Long songId = 1L;
         Song song = new Song("Title", true);

--- a/src/test/java/com/dylabs/zuko/service/SongServiceUnitTest.java
+++ b/src/test/java/com/dylabs/zuko/service/SongServiceUnitTest.java
@@ -67,7 +67,7 @@ class SongServiceUnitTest {
 
     // Crear canción con rol ADMIN
     @Test
-    @DisplayName("CP01 - Crear canción como Administrador exitosamente")
+    @DisplayName("CP01 - HU01 - Crear canción como Administrador exitosamente")
     void createSongAsAdminSuccess() {
         SongRequest request = new SongRequest("Just The Way You Are", true, artist.getId());
         Song song = new Song(request.title(), request.isPublicSong());
@@ -92,7 +92,7 @@ class SongServiceUnitTest {
 
     // Crear canción con rol ARTIST
     @Test
-    @DisplayName("CP01 - Crear canción como Artista exitosamente")
+    @DisplayName("CP02 - HU01 - Crear canción como Artista exitosamente")
     void createSongAsArtistSuccess() {
         SongRequest request = new SongRequest("Locked Out of Heaven", true, 99L);
         Song song = new Song(request.title(), request.isPublicSong());
@@ -116,7 +116,7 @@ class SongServiceUnitTest {
     }
 
     @Test
-    @DisplayName("CP02 - Crear canción con título duplicado")
+    @DisplayName("CP03 - HU01  Crear canción con título duplicado")
     void createSongTitleDuplicateThrows() {
         SongRequest request = new SongRequest("Grenade", true, artist.getId());
 
@@ -130,7 +130,7 @@ class SongServiceUnitTest {
 
     // Editar canción como ADMIN exitosamente
     @Test
-    @DisplayName("CP01 - Editar canción como Administrador exitosamente")
+    @DisplayName("CP01 - HU02 - Editar canción como Administrador exitosamente")
     void updateSongAsAdminSuccess() {
         Long songId = 1L;
         SongRequest request = new SongRequest("Grenade", true, artist.getId());
@@ -153,7 +153,7 @@ class SongServiceUnitTest {
 
     // Editar canción como ARTIST exitosamente
     @Test
-    @DisplayName("CP01 - Editar canción como Artista exitosamente")
+    @DisplayName("CP02 - HU02 - Editar canción como Artista exitosamente")
     void updateSongAsArtistSuccess() {
         Long songId = 1L;
         SongRequest request = new SongRequest("Locked Out of Heaven", true, 99L);
@@ -175,7 +175,7 @@ class SongServiceUnitTest {
     }
 
     @Test
-    @DisplayName("CP03 - Editar canción inexistente")
+    @DisplayName("CP03 - HU02 - Editar canción inexistente")
     void updateSongNotFoundThrows() {
         Long songId = 99L;
         SongRequest request = new SongRequest("Locked Out of Heaven", true, artist.getId());
@@ -192,7 +192,7 @@ class SongServiceUnitTest {
 
     // Eliminar canción como ADMIN exitosamente
     @Test
-    @DisplayName("CP01 - Eliminar canción como Administrador exitosamente")
+    @DisplayName("CP01 - HU03 - Eliminar canción como Administrador exitosamente")
     void deleteSongAsAdminSuccess() {
         Long songId = 1L;
         Song song = new Song("Treasure", true);
@@ -211,7 +211,7 @@ class SongServiceUnitTest {
 
     // Eliminar canción como ARTIST exitosamente
     @Test
-    @DisplayName("CP01 - Eliminar canción como Artista exitosamente")
+    @DisplayName("CP02 - HU03 - Eliminar canción como Artista exitosamente")
     void deleteSongAsArtistSuccess() {
         Long songId = 1L;
         Song song = new Song("Treasure", true);
@@ -230,7 +230,7 @@ class SongServiceUnitTest {
     }
 
     @Test
-    @DisplayName("CP02 - Eliminar canción inexistente")
+    @DisplayName("CP03 - HU03 - Eliminar canción inexistente")
     void deleteSongNotFoundThrows() {
         Long songId = 999L;
 
@@ -245,7 +245,7 @@ class SongServiceUnitTest {
 
 
     @Test
-    @DisplayName("CP02 - Editar canción como Usuario sin perfil de artista")
+    @DisplayName("CP04 - HU02 - Editar canción como Usuario sin perfil de artista")
     void updateSongAsArtistWithoutProfileThrows() {
         Long songId = 1L;
         SongRequest request = new SongRequest("New Title", true, 99L);
@@ -266,7 +266,7 @@ class SongServiceUnitTest {
     }
 
     @Test
-    @DisplayName("CP03 - Editar canción como Artista pero no le pertenece la canción")
+    @DisplayName("CP05 - HU02 - Editar canción como Artista pero no le pertenece la canción")
     void updateSongAsArtistNotOwnerThrows() {
         Long songId = 1L;
         SongRequest request = new SongRequest("New Title", true, 99L);
@@ -290,7 +290,7 @@ class SongServiceUnitTest {
 
 
     @Test
-    @DisplayName("CP02 - Eliminar canción como Usuario sin perfil de artista")
+    @DisplayName("CP04 - HU03 -Eliminar canción como Usuario sin perfil de artista")
     void deleteSongAsArtistWithoutProfileThrows() {
         Long songId = 1L;
         Song song = new Song("Title", true);
@@ -311,7 +311,7 @@ class SongServiceUnitTest {
 
 
     @Test
-    @DisplayName("CP03 - Eliminar canción como Artista pero no le pertenece la canción")
+    @DisplayName("CP05 - HU03 - Eliminar canción como Artista pero no le pertenece la canción")
     void deleteSongAsArtistNotOwnerThrows() {
         Long songId = 1L;
         Song song = new Song("Title", true);


### PR DESCRIPTION
Se implementaron mejoras de seguridad y autorización en la clase Song para asegurar que solo usuarios con permisos adecuados (ADMIN o ARTIST autenticado) puedan crear, editar o eliminar canciones. Además, se actualizaron y añadieron pruebas unitarias para cubrir estos nuevos controles de acceso y garantizar la correcta funcionalidad del servicio.

Cambios principales:

Validaciones de roles y autorización en métodos de creación, actualización y eliminación.

Ajustes en el manejo de la relación entre usuarios ARTIST y sus canciones.

Pruebas unitarias ampliadas y adaptadas para cubrir todos los casos de permisos.

Resultados de cobertura:

Métodos: 100%
Líneas: 100%
Ramas: 100%

Las nuevas pruebas se ejecutaron correctamente de forma local y validan los comportamientos esperados del módulo.