### PR TITLE
feat: agregar docker-compose de producción y README con instrucciones de despliegue

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,61 @@
-#Zuko
+# Zuko Backend - Deploy con Docker Compose
 
+Este proyecto contiene el backend de la aplicación Zuko, construido en Spring Boot y preparado para correr en cualquier entorno con Docker y Docker Compose.
 
-Lanzar la DB con  ``sudo docker compose up``
+## 🚀 Requisitos
+
+- Docker (https://docs.docker.com/get-docker/)
+- Docker Compose (https://docs.docker.com/compose/)
+- Docker Desktop en Windows/Mac ya incluye Docker Compose
+
+## ⚡️ Levantar el stack completo (backend + base de datos)
+
+1. Clona este repositorio.
+2. Ve a la carpeta del proyecto.
+3. Ejecuta:
+    ```bash
+    docker-compose up
+    ```
+   > Esto descarga (si no la tienes) la imagen del backend `turppie/zuko-backend:latest` y la imagen oficial de Postgres, y levanta todo el entorno automáticamente.
+
+## 🛠 Variables de entorno usadas
+
+- `SPRING_DATASOURCE_URL=jdbc:postgresql://db:5432/zuko_db`
+- `SPRING_DATASOURCE_USERNAME=postgres`
+- `SPRING_DATASOURCE_PASSWORD=adminadmin`
+- `SPRING_JPA_HIBERNATE_DDL_AUTO=update`
+
+## 🌐 Endpoints
+
+El backend estará disponible en:
+
+http://localhost:8080/api/v1/
+
+Consulta la documentación de la API o Swagger para rutas y uso.
+
+(USA POSTMAN NOMAS FRACAZOE)
+## 🧑‍💻 Uso en desarrollo
+
+Para modificar el código y probar en caliente:
+```bash
+  docker-compose -f docker-compose.dev.yml up --build
+```
+Esto construye la imagen desde el Dockerfile local.
+
+## 🐳 Imagen Docker
+
+Puedes bajar la imagen directamente con:
+```bash
+  docker pull turppie/zuko-backend:latest
+```
+## 📝 Notas
+
+El volumen postgres-data garantiza que los datos de la base no se pierdan si detienes o reinicias los contenedores.
+
+Si cambias credenciales o nombres de la base, edita el docker-compose.yml.
+
+Recuerda cerrar servicios previos en el puerto 5432 si tienes un Postgres local.
+
+Cualquier duda, sugerencia o mejora, ¡abre un issue o contáctame!
+
+---

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ http://localhost:8080/api/v1/
 
 Consulta la documentación de la API o Swagger para rutas y uso.
 
-(USA POSTMAN NOMAS FRACAZOE)
+(DOCUMENTACIÓN DE LA API PENDIENTE/ USAR POSTMAN PARA PROBAR LOS ENDPOINTS EQUIPO DYLABS)
 ## 🧑‍💻 Uso en desarrollo
 
 Para modificar el código y probar en caliente:

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,7 +1,7 @@
 version: '3.8'
 services:
   app:
-    image: turppie/zuko-backend:latest
+    build: .
     container_name: springboot-app
     ports:
       - "8080:8080"


### PR DESCRIPTION
Este pull request añade el archivo docker-compose.yml para despliegue y testing usando la imagen publicada en Docker Hub, mejorando la portabilidad y la facilidad de integración para el equipo.

- Agrega docker-compose.yml que utiliza la imagen turppie/zuko-backend:latest, permitiendo levantar backend y base de datos con un solo comando.
- Actualiza y documenta el README con pasos claros para levantar el entorno con Docker Compose, tanto para desarrollo como para producción.
- Mantiene el archivo docker-compose.dev.yml para facilitar el desarrollo local y pruebas en caliente.

Esto simplifica el onboarding de nuevos colaboradores y facilita despliegues en cualquier entorno.
