### PR TITLE
Feat: Arreglar manejo de canciones dentro del AlbumService

### DIFF
--- a/src/main/java/com/dylabs/zuko/controller/AlbumController.java
+++ b/src/main/java/com/dylabs/zuko/controller/AlbumController.java
@@ -7,7 +7,6 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
@@ -24,7 +23,7 @@ public class AlbumController {
     @PostMapping
     @PreAuthorize("hasRole('ADMIN') or hasRole('USER')")
     public ResponseEntity<Object> createAlbum(@RequestBody @Valid AlbumRequest request, Authentication authentication) {
-        // Recupera el ID del usuario autenticado desde el token
+
         String userIdFromToken = authentication.getName();
         AlbumResponse response = albumService.createAlbum(request, userIdFromToken);
         return ResponseEntity.status(HttpStatus.CREATED).body(
@@ -38,7 +37,7 @@ public class AlbumController {
     @GetMapping("/{id}")
     @PreAuthorize("hasRole('ADMIN') or hasRole('USER')")
     public ResponseEntity<Object> getAlbumById(@PathVariable Long id, Authentication authentication) {
-        // Recupera el ID del usuario autenticado desde el token (en caso de futuras validaciones)
+
         String userIdFromToken = authentication.getName();
         AlbumResponse response = albumService.getAlbumById(id);
         return ResponseEntity.ok(
@@ -52,7 +51,7 @@ public class AlbumController {
     @PutMapping("/{id}")
     @PreAuthorize("hasRole('ADMIN') or hasRole('USER')")
     public ResponseEntity<Object> updateAlbum(@PathVariable Long id, @RequestBody @Valid AlbumRequest request, Authentication authentication) {
-        // Recupera el ID del usuario autenticado desde el token
+
         String userIdFromToken = authentication.getName();
         AlbumResponse response = albumService.updateAlbum(id, request, userIdFromToken);
         return ResponseEntity.ok(
@@ -66,7 +65,7 @@ public class AlbumController {
     @DeleteMapping("/{id}")
     @PreAuthorize("hasRole('ADMIN') or hasRole('USER')")
     public ResponseEntity<Object> deleteAlbum(@PathVariable Long id, Authentication authentication) {
-        // Recupera el ID del usuario autenticado desde el token
+
         String userIdFromToken = authentication.getName();
         albumService.deleteAlbum(id, userIdFromToken);
         return ResponseEntity.ok(

--- a/src/main/java/com/dylabs/zuko/model/Album.java
+++ b/src/main/java/com/dylabs/zuko/model/Album.java
@@ -2,6 +2,7 @@ package com.dylabs.zuko.model;
 
 import jakarta.persistence.*;
 import java.time.LocalDate;
+import java.util.ArrayList;
 import java.util.List;
 
 @Entity
@@ -26,17 +27,17 @@ public class Album {
     @JoinColumn(name = "artist_id")
     private Artist artist;
 
-    @OneToMany(cascade = CascadeType.ALL, orphanRemoval = true)
+    @OneToMany
     @JoinColumn(name = "album_id")
-    private List<Song> songs;
+    private List<Song> songs = new ArrayList<>();
 
     @ManyToOne(optional = false)
     @JoinColumn(name = "genre_id")
     private Genre genre;
 
-    private LocalDate releaseDate; // Fecha de lanzamiento
+    private LocalDate releaseDate;
 
-    private LocalDate creationDate; // Nueva propiedad para la fecha de creación automática
+    private LocalDate creationDate;
 
     // Getters
 


### PR DESCRIPTION
Este PR implementa y refuerza la validación de canciones asociadas a álbumes, asegurando la integridad de datos y la correcta gestión de relaciones entre entidades.

Incluye los siguientes cambios:

🔹 Controller: Se quitaron comentarios innecesarios para mantener la limpieza y orden del codigo.

🔹 Service: Se añadió validación en AlbumService para que solo se puedan asociar canciones existentes y pertenecientes al artista correspondiente al crear o actualizar un álbum.

🔹 Model: Se modificó la relación @OneToMany en la entidad Album para evitar la eliminación de canciones

🔹 Tests: Se agregaron tests unitarios negativos y de borde en AlbumServiceUnitTest para cubrir los nuevos caminos de validación (canción inexistente, canción de otro artista).

Resultados de cobertura (AlbumService):

Métodos: 100%
Líneas: 100%
Ramas: 100%
