### PR TITLE
Feat: Corregir manejo al buscar y obtener albums

### DIFF
--- a/src/main/java/com/dylabs/zuko/controller/AlbumController.java
+++ b/src/main/java/com/dylabs/zuko/controller/AlbumController.java
@@ -1,5 +1,6 @@
 package com.dylabs.zuko.controller;
 
+import com.dylabs.zuko.dto.ApiResponse;
 import com.dylabs.zuko.dto.request.AlbumRequest;
 import com.dylabs.zuko.dto.response.AlbumResponse;
 import com.dylabs.zuko.service.AlbumService;
@@ -11,6 +12,7 @@ import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
 import java.util.Map;
 
 @RestController
@@ -47,6 +49,38 @@ public class AlbumController {
                 )
         );
     }
+
+    @GetMapping("/search")
+    @PreAuthorize("hasRole('ADMIN') or hasRole('USER')")
+    public ResponseEntity<Object> getAlbumsByTitle(@RequestParam String title) {
+        List<AlbumResponse> response = albumService.getAlbumsByTitle(title);
+        return ResponseEntity.ok(
+                Map.of(
+                        "message", "Álbumes obtenidos correctamente",
+                        "data", response
+                )
+        );
+    }
+
+    @GetMapping("/search/artist")
+    @PreAuthorize("hasRole('ADMIN') or hasRole('USER')")
+    public ResponseEntity<Object> getAlbumsByTitleAndUser(@RequestParam String title, Authentication authentication) {
+        String userIdFromToken = authentication.getName();
+        List<AlbumResponse> response = albumService.getAlbumsByTitleAndUser(title, userIdFromToken);
+        return ResponseEntity.ok(
+                Map.of(
+                        "message", "Álbumes obtenidos correctamente para el artista",
+                        "data", response
+                )
+        );
+    }
+
+    @GetMapping
+    public ResponseEntity<ApiResponse<List<AlbumResponse>>> getAllAlbums() {
+        List<AlbumResponse> response = albumService.getAllAlbums();
+        return ResponseEntity.ok(new ApiResponse<>("Álbumes obtenidos correctamente", response));
+    }
+
 
     @PutMapping("/{id}")
     @PreAuthorize("hasRole('ADMIN') or hasRole('USER')")

--- a/src/main/java/com/dylabs/zuko/repository/AlbumRepository.java
+++ b/src/main/java/com/dylabs/zuko/repository/AlbumRepository.java
@@ -4,6 +4,8 @@ import com.dylabs.zuko.model.Album;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 public interface AlbumRepository extends JpaRepository<Album, Long> {
     boolean existsByTitleIgnoreCaseAndArtistId(String title, Long artistId);
@@ -11,4 +13,8 @@ public interface AlbumRepository extends JpaRepository<Album, Long> {
     boolean existsByTitleIgnoreCaseAndArtistIdAndIdNot(String title, Long artistId, Long id);
 
     boolean existsByGenreId(Long genreId);
+
+    List<Album> findAllByTitleContainingIgnoreCase(String title);
+    List<Album> findAllByTitleContainingIgnoreCaseAndArtistId(String title, Long artistId);
+    List<Album> findAllByOrderByTitleAsc();
 }

--- a/src/main/java/com/dylabs/zuko/service/AlbumService.java
+++ b/src/main/java/com/dylabs/zuko/service/AlbumService.java
@@ -92,10 +92,42 @@ public class AlbumService {
     }
 
 
+
+
     public AlbumResponse getAlbumById(Long id) {
         Album album = albumRepository.findById(id)
                 .orElseThrow(() -> new AlbumNotFoundException("Álbum no disponible."));
         return albumMapper.toResponse(album);
+    }
+
+    public List<AlbumResponse> getAlbumsByTitle(String title) {
+        List<Album> albums = albumRepository.findAllByTitleContainingIgnoreCase(title);
+        if (albums.isEmpty()) {
+            throw new AlbumNotFoundException("No se encontraron álbumes con el título especificado.");
+        }
+        return albums.stream().map(albumMapper::toResponse).collect(Collectors.toList());
+    }
+
+    public List<AlbumResponse> getAlbumsByTitleAndUser(String title, String userIdFromToken) {
+        User user = userRepository.findById(Long.parseLong(userIdFromToken))
+                .orElseThrow(() -> new ArtistNotFoundException("Usuario no encontrado"));
+
+        Artist artist = artistRepository.findByUserId(user.getId())
+                .orElseThrow(() -> new ArtistNotFoundException("No tienes un perfil de artista."));
+
+        List<Album> albums = albumRepository.findAllByTitleContainingIgnoreCaseAndArtistId(title, artist.getId());
+        if (albums.isEmpty()) {
+            throw new AlbumNotFoundException("No se encontraron álbumes con el título especificado para este artista.");
+        }
+        return albums.stream().map(albumMapper::toResponse).collect(Collectors.toList());
+    }
+
+    public List<AlbumResponse> getAllAlbums() {
+        List<Album> albums = albumRepository.findAll();
+        if (albums.isEmpty()) {
+            throw new AlbumNotFoundException("No se encontraron álbumes.");
+        }
+        return albums.stream().map(albumMapper::toResponse).collect(Collectors.toList());
     }
 
 
@@ -152,7 +184,6 @@ public class AlbumService {
 
         return albumMapper.toResponse(album);
     }
-
 
 
     public void deleteAlbum(Long id, String userIdFromToken) {


### PR DESCRIPTION
Se agregaron funciones necesarias de busqueda por nombre del album para el uso en frontend:

- Busqueda de todos los albumes
- Busqueda de albumes para el propio ususario artista
- Busqueda de un album por nombre


Resultados de cobertura (AlbumService):

Métodos: 100%
Líneas: 100%
Ramas: 100%