### PR TITLE
Endpoint para obtener álbum a partir del ID de canción

### DIFF
--- a/src/main/java/com/dylabs/zuko/controller/AlbumController.java
+++ b/src/main/java/com/dylabs/zuko/controller/AlbumController.java
@@ -108,4 +108,17 @@ public class AlbumController {
                 )
         );
     }
+
+    @GetMapping("/from-song/{songId}")
+    @PreAuthorize("hasRole('ADMIN') or hasRole('USER')")
+    public ResponseEntity<Object> getAlbumBySongId(@PathVariable Long songId) {
+        AlbumResponse response = albumService.getAlbumBySongId(songId);
+        return ResponseEntity.ok(
+                Map.of(
+                        "message", "Álbum encontrado por ID de canción",
+                        "data", response
+                )
+        );
+    }
+
 }

--- a/src/main/java/com/dylabs/zuko/controller/PlaylistController.java
+++ b/src/main/java/com/dylabs/zuko/controller/PlaylistController.java
@@ -2,6 +2,7 @@ package com.dylabs.zuko.controller;
 import com.dylabs.zuko.dto.ApiResponse;
 import com.dylabs.zuko.dto.request.AddSongtoPlaylistRequest;
 import com.dylabs.zuko.dto.request.PlaylistRequest;
+import com.dylabs.zuko.dto.request.UpdatePlaylistRequest;
 import com.dylabs.zuko.dto.response.PlaylistResponse;
 import com.dylabs.zuko.dto.response.SongResponse;
 import com.dylabs.zuko.service.PlaylistService;
@@ -100,6 +101,18 @@ public class PlaylistController {
         List<PlaylistResponse> response = playlistService.getAllPlaylistsByUser(userId);
         return ResponseEntity.ok(new ApiResponse<>("Playlists obtenidas correctamente", response));
     }
+
+    @PatchMapping("/{playlistId}")
+    public ResponseEntity<Object> updatePlaylist(
+            @PathVariable Long playlistId,
+            @RequestBody UpdatePlaylistRequest updatePlaylistRequest,
+            Authentication authentication) {
+        String userId = authentication.getName();
+        PlaylistResponse response = playlistService.editPlaylistById(playlistId, userId, updatePlaylistRequest);
+        return ResponseEntity.ok(new ApiResponse<>("Playlist editada correctamente", response));
+
+    }
+
 
 
 

--- a/src/main/java/com/dylabs/zuko/dto/request/UpdatePlaylistRequest.java
+++ b/src/main/java/com/dylabs/zuko/dto/request/UpdatePlaylistRequest.java
@@ -1,0 +1,11 @@
+package com.dylabs.zuko.dto.request;
+
+import jakarta.validation.constraints.Size;
+
+public record UpdatePlaylistRequest(
+        @Size(min = 3, message = "El nombre debe tener al menos 3 caracteres")
+        String name,
+        String description,
+        boolean isPublic,
+        String url_image
+) {}

--- a/src/main/java/com/dylabs/zuko/repository/AlbumRepository.java
+++ b/src/main/java/com/dylabs/zuko/repository/AlbumRepository.java
@@ -2,9 +2,12 @@ package com.dylabs.zuko.repository;
 
 import com.dylabs.zuko.model.Album;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface AlbumRepository extends JpaRepository<Album, Long> {
@@ -17,4 +20,6 @@ public interface AlbumRepository extends JpaRepository<Album, Long> {
     List<Album> findAllByTitleContainingIgnoreCase(String title);
     List<Album> findAllByTitleContainingIgnoreCaseAndArtistId(String title, Long artistId);
     List<Album> findAllByOrderByTitleAsc();
+    @Query("SELECT a FROM Album a JOIN a.songs s WHERE s.id =:songId")
+    Optional<Album> findAlbumBySongId(@Param("songId") Long songId);
 }

--- a/src/main/java/com/dylabs/zuko/service/AlbumService.java
+++ b/src/main/java/com/dylabs/zuko/service/AlbumService.java
@@ -199,4 +199,11 @@ public class AlbumService {
         albumRepository.delete(album);
     }
 
+    public AlbumResponse getAlbumBySongId(Long songId) {
+        Album album = albumRepository.findAlbumBySongId(songId)
+                .orElseThrow(() -> new AlbumNotFoundException("No se encontró un álbum para esta canción"));
+        return albumMapper.toResponse(album);
+    }
+
+
 }

--- a/src/main/java/com/dylabs/zuko/service/PlaylistService.java
+++ b/src/main/java/com/dylabs/zuko/service/PlaylistService.java
@@ -1,6 +1,7 @@
 package com.dylabs.zuko.service;
 
 import com.dylabs.zuko.dto.request.PlaylistRequest;
+import com.dylabs.zuko.dto.request.UpdatePlaylistRequest;
 import com.dylabs.zuko.dto.response.PlaylistResponse;
 import com.dylabs.zuko.dto.response.SongResponse;
 import com.dylabs.zuko.exception.artistExeptions.ArtistNotFoundException;
@@ -167,6 +168,38 @@ public class PlaylistService {
             throw new PlaylistNotPublicException("La playlist es privada");
         }
         return playlistMapper.toResponse(playlist);
+    }
+
+    public PlaylistResponse editPlaylistById(Long playlistId, String userId, UpdatePlaylistRequest updatePlaylistRequest) {
+        User user = userRepository.findById(Long.parseLong(userId))
+                .orElseThrow(() -> new ArtistNotFoundException("Usuario no encontrado con id: " + userId));
+
+        Playlist playlist = playlistRepository.findById(playlistId)
+                .orElseThrow(() -> new PlaylistNotFoundException("Playlist no encontrada con ID: " + playlistId));
+
+        boolean isOwner = playlist.getUser().getId().equals(user.getId());
+        boolean isAdmin = user.getUserRoleName().equalsIgnoreCase("ADMIN");
+        if (!isOwner && !isAdmin) {
+            throw new PlaylistAccessDeniedException("No tienes permisos para modificar esta playlist.");
+        }
+
+        if (updatePlaylistRequest.name() !=null)
+        {
+            playlist.setName(updatePlaylistRequest.name());
+        }
+        if (updatePlaylistRequest.description() !=null){
+            playlist.setDescription(updatePlaylistRequest.description());
+        }
+
+        playlist.setPublic(updatePlaylistRequest.isPublic());
+
+        if (updatePlaylistRequest.url_image() !=null){
+            playlist.setUrl_image(updatePlaylistRequest.url_image());
+        }
+
+        return playlistMapper.toResponse(playlist);
+
+
     }
 
 


### PR DESCRIPTION
Resumen
Se implementa un nuevo endpoint en el módulo de álbumes que permite obtener la información de un álbum dado el songId de una de sus canciones. Este endpoint facilita la consulta cruzada desde cualquier parte del frontend (por ejemplo, vista de playlist, detalles de canción, etc).

Cambios principales
Agregado método findAlbumBySongId en AlbumRepository (con JPQL join).

Agregado método getAlbumBySongId(Long songId) en AlbumService.

Nuevo endpoint GET /albums/from-song/{songId} en AlbumController.

Manejo de excepción si la canción no pertenece a ningún álbum.

Endpoint probado y funcional, retorna la info estructurada en el DTO AlbumResponse.

Motivación
Permite al frontend mostrar el álbum al que pertenece una canción incluso si el modelo Song no tiene relación directa con Album. Mejora la experiencia de usuario y la navegabilidad.

Consideraciones
No afecta endpoints existentes.

Maneja el caso en que una canción no tenga álbum.

Es una solución temporal mientras no se reestructure la relación Song ↔ Album.