### PR TITLE
 Endpoint PATCH para editar Playlists

### DIFF
--- a/src/main/java/com/dylabs/zuko/controller/PlaylistController.java
+++ b/src/main/java/com/dylabs/zuko/controller/PlaylistController.java
@@ -105,6 +105,7 @@ public class PlaylistController {
     @PatchMapping("/{playlistId}")
     public ResponseEntity<Object> updatePlaylist(
             @PathVariable Long playlistId,
+            @Valid
             @RequestBody UpdatePlaylistRequest updatePlaylistRequest,
             Authentication authentication) {
         String userId = authentication.getName();

--- a/src/main/java/com/dylabs/zuko/dto/request/PlaylistRequest.java
+++ b/src/main/java/com/dylabs/zuko/dto/request/PlaylistRequest.java
@@ -8,6 +8,7 @@ public record PlaylistRequest(
         @NotBlank(message = "El nombre es obligatorio")
         @Size(min = 3, message = "El nombre debe tener al menos 3 caracteres")
         String name,
+        @Size(max=200,message = "La descripción no puede exceder 200 caracteres")
         String description,
         boolean isPublic,
         String url_image

--- a/src/main/java/com/dylabs/zuko/dto/request/UpdatePlaylistRequest.java
+++ b/src/main/java/com/dylabs/zuko/dto/request/UpdatePlaylistRequest.java
@@ -1,10 +1,12 @@
 package com.dylabs.zuko.dto.request;
 
+import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 
 public record UpdatePlaylistRequest(
         @Size(min = 3, message = "El nombre debe tener al menos 3 caracteres")
         String name,
+        @Size(max=200,message = "La descripción no puede exceder 200 caracteres")
         String description,
         boolean isPublic,
         String url_image

--- a/src/main/java/com/dylabs/zuko/service/PlaylistService.java
+++ b/src/main/java/com/dylabs/zuko/service/PlaylistService.java
@@ -193,7 +193,9 @@ public class PlaylistService {
 
         playlist.setPublic(updatePlaylistRequest.isPublic());
 
-        if (updatePlaylistRequest.url_image() !=null){
+        if (updatePlaylistRequest.url_image().isBlank()) {
+            playlist.setUrl_image(null);
+        } else {
             playlist.setUrl_image(updatePlaylistRequest.url_image());
         }
 

--- a/src/main/java/com/dylabs/zuko/service/PlaylistService.java
+++ b/src/main/java/com/dylabs/zuko/service/PlaylistService.java
@@ -197,6 +197,8 @@ public class PlaylistService {
             playlist.setUrl_image(updatePlaylistRequest.url_image());
         }
 
+        playlistRepository.save(playlist);
+
         return playlistMapper.toResponse(playlist);
 
 


### PR DESCRIPTION
Cambios principales
Nuevo endpoint PATCH

Se añadió el endpoint PATCH /playlists/{playlistId} para editar los atributos de una playlist (nombre, descripción, portada, privacidad).

DTO especializado

Creación de UpdatePlaylistRequest con validaciones (@Size, @NotBlank, etc) para los campos editables de la playlist.

Lógica de servicio

Nuevo método editPlaylistById en el PlaylistService para manejar la actualización de los datos, con validación de permisos (owner/admin).

Se asegura que solo los campos enviados se actualizan (permite parches parciales).

Validación adicional para evitar que se guarde un nombre vacío.

Mapper

Revisión del mapper para asegurar que los cambios persistan correctamente y se reflejen en la respuesta.

Validación
Se verifica que el usuario solo pueda editar playlists propias o siendo admin.

Todos los campos cumplen las validaciones y restricciones del modelo.

El endpoint responde correctamente con el nuevo estado de la playlist.