### PR TITLE
feat(playlist): búsqueda global de playlists públicas por nombre

### DIFF
--- a/src/main/java/com/dylabs/zuko/controller/PlaylistController.java
+++ b/src/main/java/com/dylabs/zuko/controller/PlaylistController.java
@@ -81,10 +81,10 @@ public class PlaylistController {
                 new ApiResponse<>("Canción eliminada correctamente", null));
     }
 
-    @GetMapping("/public/by-name/{playlistName}")
-    public ResponseEntity<Object> getPublicPlaylistByName(@PathVariable String playlistName) {
-        PlaylistResponse response = playlistService.getPublicPlaylistByName(playlistName);
-        return ResponseEntity.ok(new ApiResponse<>("Playlist obtenida correctamente", response));
+    @GetMapping("/public/search")
+    public ResponseEntity<Object> searchPublicPlaylistsByName(@RequestParam String name) {
+        List<PlaylistResponse> playlists = playlistService.searchPublicPlaylistsByName(name);
+        return ResponseEntity.ok(new ApiResponse<>("Playlists encontradas", playlists));
     }
 
     @GetMapping("/by-name/{playlistName}")

--- a/src/main/java/com/dylabs/zuko/dto/response/PlaylistResponse.java
+++ b/src/main/java/com/dylabs/zuko/dto/response/PlaylistResponse.java
@@ -10,5 +10,6 @@ public record PlaylistResponse(
         boolean isPublic,
         LocalDate createdAt,
         Set<SongResponse> songs,
-        String url_image
+        String url_image,
+        Long userID
 ) {}

--- a/src/main/java/com/dylabs/zuko/mapper/PlaylistMapper.java
+++ b/src/main/java/com/dylabs/zuko/mapper/PlaylistMapper.java
@@ -30,7 +30,8 @@ public class PlaylistMapper {
                 playlist.getSongs().stream()
                         .map(this::toSongResponse)
                         .collect(Collectors.toSet()),
-                playlist.getUrl_image()
+                playlist.getUrl_image(),
+                playlist.getUser().getId()
         );
         return playlistResponse;
     }

--- a/src/main/java/com/dylabs/zuko/repository/PlaylistRepository.java
+++ b/src/main/java/com/dylabs/zuko/repository/PlaylistRepository.java
@@ -17,4 +17,7 @@ public interface PlaylistRepository extends JpaRepository<Playlist, Long> {
     List<Playlist> findAllByUser_Id(Long userId);
 
     Optional<Playlist> findByNameIgnoreCase(String name);
+
+    List<Playlist> findByisPublicTrueAndNameContainingIgnoreCase(String name);
+
 }

--- a/src/main/java/com/dylabs/zuko/service/PlaylistService.java
+++ b/src/main/java/com/dylabs/zuko/service/PlaylistService.java
@@ -161,14 +161,14 @@ public class PlaylistService {
                 .collect(Collectors.toList());
     }
 
-    public PlaylistResponse getPublicPlaylistByName(String playlistName) {
-        Playlist playlist = playlistRepository.findByNameIgnoreCase(playlistName)
-                .orElseThrow(() -> new PlaylistNotFoundException("Playlist no encontrada con nombre: " + playlistName));
-        if (!playlist.isPublic()) {
-            throw new PlaylistNotPublicException("La playlist es privada");
-        }
-        return playlistMapper.toResponse(playlist);
+    public List<PlaylistResponse> searchPublicPlaylistsByName(String name) {
+        List<Playlist> playlists = playlistRepository
+                .findByisPublicTrueAndNameContainingIgnoreCase(name);
+        return playlists.stream()
+                .map(playlistMapper::toResponse)
+                .toList();
     }
+
 
     public PlaylistResponse editPlaylistById(Long playlistId, String userId, UpdatePlaylistRequest updatePlaylistRequest) {
         User user = userRepository.findById(Long.parseLong(userId))

--- a/src/test/java/com/dylabs/zuko/service/PlaylistServiceUnitTest.java
+++ b/src/test/java/com/dylabs/zuko/service/PlaylistServiceUnitTest.java
@@ -45,7 +45,7 @@ class PlaylistServiceUnitTest {
         User user = new User(); user.setId(1L);
         Playlist playlist = new Playlist(); playlist.setUser(user);
         Playlist saved = new Playlist(); saved.setUser(user);
-        PlaylistResponse response = new PlaylistResponse(1L, "Test", "desc", true, null, Set.of(), "si");
+        PlaylistResponse response = new PlaylistResponse(1L, "Test", "desc", true, null, Set.of(), "si", 1L);
 
         when(userRepository.findById(1L)).thenReturn(Optional.of(user));
         when(playlistRepository.existsByNameIgnoreCaseAndUser_id("Test", 1L)).thenReturn(false);


### PR DESCRIPTION
Descripción:

Se implementa endpoint REST GET /api/v1/playlists/public/search?name=... para buscar playlists públicas por nombre de forma global (sin requerir autenticación).

Se añade método en el service y repository para filtrar playlists públicas por coincidencia parcial e insensible a mayúsculas en el nombre.

Ajuste en la respuesta para devolver múltiples resultados compatibles con la UI.

Incluye validación y documentación básica en el controller.

Probado en Postman con casos de búsqueda exacta y parcial.

Notas:

No afecta endpoints privados ni la gestión personal de playlists.

Compatible con la integración del frontend de búsqueda global.

