### PR TITLE
feat(song): soporte para reproducción con enlace de YouTube

### DIFF
--- a/src/main/java/com/dylabs/zuko/dto/request/SongRequest.java
+++ b/src/main/java/com/dylabs/zuko/dto/request/SongRequest.java
@@ -9,6 +9,6 @@ public record SongRequest(
         String title,
 
         boolean isPublicSong,
-
+        String youtubeUrl,
         long artistId
 ) {}

--- a/src/main/java/com/dylabs/zuko/dto/response/SongResponse.java
+++ b/src/main/java/com/dylabs/zuko/dto/response/SongResponse.java
@@ -9,5 +9,6 @@ public record SongResponse(
         LocalDate releaseDate,
         String message,
         Long artistId,
-        String artistName
+        String artistName,
+        String youtubeUrl
 ) {}

--- a/src/main/java/com/dylabs/zuko/mapper/PlaylistMapper.java
+++ b/src/main/java/com/dylabs/zuko/mapper/PlaylistMapper.java
@@ -53,7 +53,9 @@ public class PlaylistMapper {
                 song.getReleaseDate(),
                 null,
                 song.getArtist().getId(),
-                song.getArtist().getName()
+                song.getArtist().getName(),
+                song.getYoutubeUrl()
+
         );
     }
 

--- a/src/main/java/com/dylabs/zuko/mapper/SongMapper.java
+++ b/src/main/java/com/dylabs/zuko/mapper/SongMapper.java
@@ -22,12 +22,13 @@ public class SongMapper {
                 song.getReleaseDate(),
                 "Canción registrada exitosamente", // O personalizado desde el servicio
                 artistId,
-                artistName
+                artistName,
+                song.getYoutubeUrl()
         );
     }
     // Convertir un SongRequest a la entidad Song
     public Song toSongEntity(SongRequest request, Artist artist) {
-        Song song = new Song(request.title(), request.isPublicSong());
+        Song song = new Song(request.title(), request.isPublicSong(), request.youtubeUrl());
         song.setArtist(artist);
         return song;
     }

--- a/src/main/java/com/dylabs/zuko/model/Song.java
+++ b/src/main/java/com/dylabs/zuko/model/Song.java
@@ -16,16 +16,27 @@ public class Song {
     private boolean isPublicSong;
     private LocalDate releaseDate;
 
+    @Column(name = "youtube_url")
+    private String youtubeUrl;
     @ManyToOne
     @JoinColumn(name = "artist_id", nullable = false)
     private Artist artist;
 
     public Song() {}
 
-    public Song(String title, boolean isPublicSong) {
+    public Song(String title, boolean isPublicSong, String youtubeUrl) {
         this.title = title;
         this.isPublicSong = isPublicSong;
-        this.releaseDate = LocalDate.now(); //
+        this.releaseDate = LocalDate.now();
+        this.youtubeUrl = youtubeUrl;
+    }
+
+    public String getYoutubeUrl() {
+        return youtubeUrl;
+    }
+
+    public void setYoutubeUrl(String youtubeUrl) {
+        this.youtubeUrl = youtubeUrl;
     }
 
     public long getId() {

--- a/src/main/java/com/dylabs/zuko/service/SongService.java
+++ b/src/main/java/com/dylabs/zuko/service/SongService.java
@@ -120,7 +120,9 @@ public class SongService {
                 updated.getReleaseDate(),
                 "La canción ha sido actualizada correctamente.",
                 updated.getArtist().getId(),
-                updated.getArtist().getName()
+                updated.getArtist().getName(),
+                updated.getYoutubeUrl()
+
         );
     }
 
@@ -149,7 +151,9 @@ public class SongService {
                 song.getReleaseDate(),
                 "La canción ha sido eliminada correctamente.",
                 song.getArtist().getId(),
-                song.getArtist().getName()
+                song.getArtist().getName(),
+                song.getYoutubeUrl()
+
         );
     }
 }


### PR DESCRIPTION
### ✅ Descripción
Se añade soporte para registrar y actualizar canciones con enlaces de YouTube, lo que permite su posterior reproducción desde el frontend.

### 📌 Cambios realizados
- Se agregó el campo `youtubeUrl` en:
  - `SongRequest`
  - `SongResponse`
  - Entidad `Song`
- Se actualizó `SongMapper` para incluir el nuevo campo.
- Se modificó `SongService` para guardar y actualizar correctamente el campo `youtubeUrl`.
- Se realizaron pequeños ajustes en `PlaylistMapper` (formato).
-
### 🧪 Cómo probar
1. Crear o editar una canción desde Postman enviando un campo `youtubeUrl`.
2. Verificar que se almacena correctamente en la base de datos.
3. Confirmar que el campo se devuelve en el `GET /songs`.

### 📎 Extras
Este cambio es necesario para permitir la reproducción desde el frontend usando la API de YouTube.