### PR TITLE
fix: habilitar borrado en cascada de playlists referenciadas en shortcuts

### DIFF
--- a/src/main/java/com/dylabs/zuko/model/Shortcuts.java
+++ b/src/main/java/com/dylabs/zuko/model/Shortcuts.java
@@ -17,7 +17,7 @@ public class Shortcuts {
     @JoinTable(
             name = "shortcuts_playlists",
             joinColumns = @JoinColumn(name = "shortcuts_id"),
-            inverseJoinColumns = @JoinColumn(name = "playlist_id")
+            inverseJoinColumns = @JoinColumn(name = "playlist_id", foreignKey = @ForeignKey(name = "fk_playlist", foreignKeyDefinition = "FOREIGN KEY (playlist_id) REFERENCES playlists(playlist_id) ON DELETE CASCADE"))
 
     )
     private Set<Playlist> playlists = new HashSet<>();
@@ -27,6 +27,7 @@ public class Shortcuts {
             name = "shortcuts_albums",
             joinColumns = @JoinColumn(name = "shortcuts_id"),
             inverseJoinColumns = @JoinColumn(name = "album_id")
+            // aplicar casacade aqui tmb
 
     )
     private Set<Album> albums = new HashSet<>();


### PR DESCRIPTION
##  Descripción
Este PR habilita el borrado en cascada (ON DELETE CASCADE) de playlists en la relación many-to-many con shortcuts. De ahora en adelante, al eliminar una playlist, se eliminan automáticamente todas las referencias asociadas en la tabla Intermedia, evitando errores de integridad referencial y simplificando la gestión de datos relacionados.

- Facilita la limpieza automática de accesos directos al eliminar playlists.

