### PR TITLE
Fix/AlbumUpdateB Feat: Añadir ID de genero en el Album Response

### DIFF
--- a/src/main/java/com/dylabs/zuko/dto/response/AlbumResponse.java
+++ b/src/main/java/com/dylabs/zuko/dto/response/AlbumResponse.java
@@ -10,5 +10,6 @@ public record AlbumResponse(
         Long artistId,
         String artistName,
         String genreName,
+        Long genreId,
         List<AlbumSongSummaryResponse> songs
 ) {}

--- a/src/main/java/com/dylabs/zuko/mapper/AlbumMapper.java
+++ b/src/main/java/com/dylabs/zuko/mapper/AlbumMapper.java
@@ -67,6 +67,7 @@ public class AlbumMapper {
                 album.getArtist().getId(),
                 album.getArtist().getName(),
                 album.getGenre().getName(),
+                album.getGenre().getId(),
                 songs
         );
     }

--- a/src/main/java/com/dylabs/zuko/mapper/ShortcutsMapper.java
+++ b/src/main/java/com/dylabs/zuko/mapper/ShortcutsMapper.java
@@ -15,15 +15,15 @@ import java.util.stream.Collectors;
 @RequiredArgsConstructor
 public class ShortcutsMapper {
     public ShortcutsResponse toShortcutsResponse(Shortcuts shortcuts) {
-           return new ShortcutsResponse(
-                    shortcuts.getId(),
-                    shortcuts.getPlaylists().stream()
-                            .map(this::toPlaylistSummary)
-                            .collect(Collectors.toSet()),
-                    shortcuts.getAlbums().stream()
-                            .map(this::toAlbumResponse)
-                            .collect(Collectors.toSet())
-            );
+        return new ShortcutsResponse(
+                shortcuts.getId(),
+                shortcuts.getPlaylists().stream()
+                        .map(this::toPlaylistSummary)
+                        .collect(Collectors.toSet()),
+                shortcuts.getAlbums().stream()
+                        .map(this::toAlbumResponse)
+                        .collect(Collectors.toSet())
+        );
 
     }
 
@@ -40,7 +40,7 @@ public class ShortcutsMapper {
     public AlbumResponse toAlbumResponse(Album album) {
         List<AlbumSongSummaryResponse> songs = album.getSongs().stream()
                 .map(song -> new AlbumSongSummaryResponse(
-                        song.getId(),          // Aquí se incluye el ID único de la canción
+                        song.getId(),
                         song.getTitle(),
                         song.getReleaseDate(),
                         song.getYoutubeUrl()
@@ -55,9 +55,9 @@ public class ShortcutsMapper {
                 album.getArtist().getId(),
                 album.getArtist().getName(),
                 album.getGenre().getName(),
+                album.getGenre().getId(),
                 songs
         );
     }
-
 
 }


### PR DESCRIPTION
Este cambio permite que el Álbum obtenga el Genero Id, permitiendo la visualización del mismo al momento de editar un Álbum.