### PR TITLE
feat(song): soporte para creación de canciones por admin y filtros por visibilidad

### DIFF
--- a/src/main/java/com/dylabs/zuko/controller/SongController.java
+++ b/src/main/java/com/dylabs/zuko/controller/SongController.java
@@ -69,4 +69,11 @@ public class SongController {
         String username = authentication.getName();
         return songService.deleteSong(id, username);
     }
+
+    @GetMapping("/all")
+    @PreAuthorize("hasRole('ADMIN')")
+    public ResponseEntity<List<SongResponse>> getAllSongs() {
+        List<SongResponse> songs = songService.getAllSongs();
+        return ResponseEntity.ok(songs);
+    }
 }

--- a/src/main/java/com/dylabs/zuko/repository/SongRepository.java
+++ b/src/main/java/com/dylabs/zuko/repository/SongRepository.java
@@ -10,4 +10,5 @@ public interface SongRepository extends JpaRepository<Song, Long> {
     boolean existsByTitleIgnoreCaseAndArtistId(String title, Long artistId);
     List<Song> findByTitleContainingIgnoreCaseAndIsPublicSongTrue(String title);
     List<Song> findAllByArtistId(Long artistId);
+    List<Song> findAll();
 }

--- a/src/main/java/com/dylabs/zuko/service/SongService.java
+++ b/src/main/java/com/dylabs/zuko/service/SongService.java
@@ -29,6 +29,7 @@ public class SongService {
     private final SongMapper songMapper;
     private final ArtistRepository artistRepository;
     private final UserRepository userRepository;
+    private final SongRepository songRepository;
 
     // Crear canción
     public SongResponse createSong(SongRequest request, String userIdFromToken) {
@@ -87,6 +88,13 @@ public class SongService {
             throw new SongNotFoundException("No existe la canción buscada.");
         }
 
+        return songs.stream()
+                .map(songMapper::toResponse)
+                .toList();
+    }
+
+    public List<SongResponse> getAllSongs() {
+        List<Song> songs = songRepository.findAll();
         return songs.stream()
                 .map(songMapper::toResponse)
                 .toList();


### PR DESCRIPTION
Se actualiza el SongController y el SongService para permitir que un administrador cree canciones asignando un artistId.

Se ajusta el SongRepository para soportar estas nuevas consultas.