### PR TITLE
Feat: Arreglar ultimos 3 albumes de la DB

### DIFF
--- a/src/main/java/com/dylabs/zuko/repository/AlbumRepository.java
+++ b/src/main/java/com/dylabs/zuko/repository/AlbumRepository.java
@@ -28,6 +28,5 @@ public interface AlbumRepository extends JpaRepository<Album, Long> {
     Optional<Album> findAlbumBySongId(@Param("songId") Long songId);
     List<Album> findAllByArtistId(Long artistId);
 
-    @Query("SELECT a FROM Album a WHERE a.releaseDate = CURRENT_DATE ORDER BY a.releaseDate DESC, a.id DESC")
-    Page<Album> findTopByReleaseDateToday(Pageable pageable);
+    List<Album> findTop3ByOrderByIdDesc();
 }

--- a/src/main/java/com/dylabs/zuko/service/AlbumService.java
+++ b/src/main/java/com/dylabs/zuko/service/AlbumService.java
@@ -292,9 +292,10 @@ public class AlbumService {
     }
 
     public List<ReleaseItemResponse> getTop3PublicAlbums() {
-        Pageable limit = PageRequest.of(0, 3); // Página 0, máximo 3 resultados
-        List<Album> albums = albumRepository.findTopByReleaseDateToday(limit).getContent();
+        // Obtenemos los 3 últimos álbumes
+        List<Album> albums = albumRepository.findTop3ByOrderByIdDesc();
 
+        // Convertimos los álbumes al formato esperado
         return albums.stream()
                 .map(album -> new ReleaseItemResponse(
                         album.getId(),


### PR DESCRIPTION
Se arreglo el manejo de álbumes en nuevos lanzamientos, ahora en ves de mostrarse los últimos 3 lanzamientos de álbumes del día, son los 3 últimos creados de la base de datos. 