### PR TITLE
chore: agregar maximum-pool-size en application.properties

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -9,3 +9,4 @@ spring.jpa.hibernate.ddl-auto=${SPRING_JPA_HIBERNATE_DDL_AUTO}
 spring.jpa.show-sql=true
 spring.jpa.properties.hibernate.format_sql=true
 security.public-paths=/api/v1/auth/login,/api/v1/auth/signup
+spring.datasource.hikari.maximum-pool-size=5


### PR DESCRIPTION
This pull request introduces a configuration change to optimize database connection pooling in the application.

* [`src/main/resources/application.properties`](diffhunk://#diff-54eeffbae371fcd1398d4ca5e89a1b8118208b7bb2f8ddf55c1aa2f7d98ab136R12): Added `spring.datasource.hikari.maximum-pool-size=5` to configure the maximum size of the Hikari connection pool, improving database connection management.